### PR TITLE
Remove the old (non Data.Vector) code and ifdefs

### DIFF
--- a/hmatrix.cabal
+++ b/hmatrix.cabal
@@ -134,7 +134,7 @@ library
     C-sources:          lib/Numeric/LinearAlgebra/LAPACK/lapack-aux.c,
                         lib/Numeric/GSL/gsl-aux.c
 
-    cpp-options:        -DVECTOR -DBINARY
+    cpp-options:        -DBINARY
 
  -- ghc-prof-options:   -auto
 

--- a/lib/Numeric/Vector.hs
+++ b/lib/Numeric/Vector.hs
@@ -25,33 +25,6 @@ import Numeric.Container
 
 -------------------------------------------------------------------
 
-#ifndef VECTOR
-import Foreign(Storable)
-#endif
-
-------------------------------------------------------------------
-
-#ifndef VECTOR
-
-instance (Show a, Storable a) => (Show (Vector a)) where
-    show v = (show (dim v))++" |> " ++ show (toList v)
-
-instance Container Vector a => Eq (Vector a) where
-    (==) = equal
-
-instance (Element a, Read a) => Read (Vector a) where
-    readsPrec _ s = [((d |>) . read $ listnums, rest)]
-        where (thing,rest) = breakAt ']' s
-              (dims,listnums) = breakAt '>' thing
-              d = read . init . fst . breakAt '|' $ dims
-              breakAt c l = (a++[c],tail b) where
-                  (a,b) = break (==c) l
-
-#endif
-
-
-------------------------------------------------------------------
-
 adaptScalar f1 f2 f3 x y
     | dim x == 1 = f1   (x@>0) y
     | dim y == 1 = f3 x (y@>0)


### PR DESCRIPTION
This is a complete no-op, it just removes dead code. The old (non
Data.Vector.Storable) implementation can no longer be selected, and this
change removes all the remaining portions of it.
