### PR TITLE
Add bindings for gsl_integrate_cquad doubly-adaptive quadrature for difficult integrands

### DIFF
--- a/lib/Numeric/GSL/gsl-aux.c
+++ b/lib/Numeric/GSL/gsl-aux.c
@@ -802,6 +802,19 @@ int integrate_qagil(double f(double,void*), double b, double prec, int w,
     OK
 }
 
+int integrate_cquad(double f(double,void*), double a, double b, double prec,
+                    int w, double *result, double* error, int *neval) {
+    DEBUGMSG("integrate_cquad");
+    gsl_integration_cquad_workspace * wk = gsl_integration_cquad_workspace_alloc (w);
+    gsl_function F;
+    F.function = f;
+    F.params = NULL;
+    int res = gsl_integration_cquad (&F, a, b, 0, prec, wk, result, error, neval); 
+    CHECK(res,res);
+    gsl_integration_cquad_workspace_free (wk); 
+    OK
+}
+
 
 int polySolve(KRVEC(a), CVEC(z)) {
     DEBUGMSG("polySolve");


### PR DESCRIPTION
This simple patch adds support for `gsl_integrate_cquad()` to `Numeric.GSL.Integration`.  `gsl_integrate_cquad()` is available in gsl version 1.15 and newer.

This patch has been tested in an ad-hoc fashion.
