### PR TITLE
Make docs of generic `instance Element Foo` more prominent

### DIFF
--- a/packages/base/src/Data/Packed/Internal/Matrix.hs
+++ b/packages/base/src/Data/Packed/Internal/Matrix.hs
@@ -253,7 +253,8 @@ compat m1 m2 = rows m1 == rows m2 && cols m1 == cols m2
     operations for selected element types.
     It provides unoptimised defaults for any 'Storable' type,
     so you can create instances simply as:
-    @instance Element Foo@.
+
+    >instance Element Foo
 -}
 class (Storable a) => Element a where
     subMatrixD :: (Int,Int) -- ^ (r0,c0) starting position 


### PR DESCRIPTION
On its own highlighted line it's easier to spot.
