### PR TITLE
link gfortran on freebsd

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -114,7 +114,7 @@ library
     if os(freebsd)
        extra-lib-dirs: /usr/local/lib
        include-dirs: /usr/local/include
-       extra-libraries: blas lapack
+       extra-libraries: blas lapack gfortran
 
     if os(windows)
         extra-libraries: blas lapack


### PR DESCRIPTION
Without this patch, I get this error when linking an executable:

```
Linking dist/dist-sandbox-d0be673a/build/findmelike/findmelike ...
/usr/local/bin/ld: /usr/home/vagrant/findmelike/.cabal-sandbox/lib/x86_64-freebsd-ghc-7.8.3/hmatrix-0.16.0.6/libHShmatrix-0.16.0.6.a(vector-aux.o): undefined reference to symbol 'cpow@@GFORTRAN_C99_1.0'
//usr/local/lib/gcc48/libgfortran.so.3: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Unfortunately it is very difficult to produce a minimal test case that triggers this. I have only tested this on FreeBSD 10.0.
