### PR TITLE
Simplify the vectore reversion in conv

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Util/Convolution.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Util/Convolution.hs
@@ -16,6 +16,7 @@ module Numeric.LinearAlgebra.Util.Convolution(
    corr2, conv2, separable
 ) where
 
+import qualified Data.Vector.Storable as SV
 import Data.Packed.Numeric
 
 
@@ -51,7 +52,7 @@ conv ker v
     | dim ker == 0 = konst 0 (dim v)
     | otherwise = corr ker' v'
   where
-    ker' = (flatten.fliprl.asRow) ker
+    ker' = SV.reverse ker
     v' = vjoin [z,v,z]
     z = konst 0 (dim ker -1)
 


### PR DESCRIPTION
Hi!

I've noticed that the convolution function uses intermediate steps to convert to matrix and back in order to flip a vector. Importing Data.Vector.Storable and using Vector.reverse directly introduces a ~30% speed gain.
I've prepared a benchmark to show this: https://gist.github.com/erdeszt/a932dbf83daf0b4e0c6b
The pr fixes the issue.
