### PR TITLE
use random() instead of drand48_r

### DIFF
--- a/packages/base/src/C/vector-aux.c
+++ b/packages/base/src/C/vector-aux.c
@@ -705,7 +705,7 @@ int saveMatrix(char * file, char * format, KDMAT(a)){
 #pragma message "randomVector is not thread-safe in OSX"
 
 inline double urandom() {
-    const long max_random = 2147483647 // 2**31 - 1
+    const long max_random = 2147483647; // 2**31 - 1
     return (double)random() / (double)max_random;
 }
 


### PR DESCRIPTION
drand48_r() cannot be used in OS X, and it also uses linear congruential generators like rand().
random(), not rand(), can be used in most UNIX systems (including OS X), and it generates better random numbers.
