### PR TITLE
Fix #282

### DIFF
--- a/packages/base/src/Internal/LAPACK.hs
+++ b/packages/base/src/Internal/LAPACK.hs
@@ -506,8 +506,10 @@ linearSolveGTAux2 g f st dl d du b
     | ndl  == nd - 1 &&
       ndu  == nd - 1 &&
       nd   == r = unsafePerformIO . g $ do
+        dl' <- head . toRows <$> copy ColumnMajor (fromRows [dl])
+        du' <- head . toRows <$> copy ColumnMajor (fromRows [du])
         s <- copy ColumnMajor b
-        (dl # d # du #! s) f #| st
+        (dl' # d # du' #! s) f #| st
         return s
     | otherwise = error $ st ++ " of nonsquare matrix"
   where

--- a/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
+++ b/packages/tests/src/Numeric/LinearAlgebra/Tests.hs
@@ -242,6 +242,29 @@ triDiagTest = utest "triDiagTest" (ok1 && ok2) where
 
 ---------------------------------------------------------------------
 
+triDiagRegression = utest "triDiagRegression" ok where
+  minusOnes, twos :: Vector R
+  minusOnes = fromList [-1, -1]
+  twos      = fromList [2, 2, 2]
+  k :: Matrix R
+  k = (3><3)
+    [  2, -1,  0
+    , -1,  2, -1
+    ,  0, -1,  2
+    ]
+
+  b :: Matrix R
+  b = (3><1) [10, 10, 10]
+
+  tridiag = triDiagSolve minusOnes twos minusOnes b
+  simple = linearSolve k b
+
+  ok = case simple of
+    Just m -> tridiag |~| m
+    Nothing -> False
+
+---------------------------------------------------------------------
+
 randomTestGaussian = (unSym c) :~3~: unSym (snd (meanCov dat))
   where
     a = (3><3) [1,2,3,
@@ -830,6 +853,7 @@ runTests n = do
         , mbCholTest
         , triTest
         , triDiagTest
+        , triDiagRegression
         , utest "offset" offsetTest
         , normsVTest
         , normsMTest


### PR DESCRIPTION
LAPACK routine dgttrf mutates its inputs per documentation. To prevent
user-visible breakage input vectors must be copied before sending them
to LAPACK.

---

Sadly I did not find something like `copyVector` function so I had to use ad-hoc solution. If there's a better one, I will change my PR.