### PR TITLE
Allow disabling random_r() usage manually.

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -36,6 +36,11 @@ flag disable-default-paths
     default:        False
     manual: True
 
+flag no-random_r
+    description:    When enabled, don't depend on the random_r() C function.
+    default:        False
+    manual: True
+
 library
 
     Build-Depends:      base >= 4.8 && < 5,
@@ -98,6 +103,9 @@ library
     if arch(i386)
         cc-options:     -msse2
 
+
+    if flag(no-random_r)
+        cc-options: -DNO_RANDOM_R
 
     if os(OSX)
         if flag(openblas)

--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -932,20 +932,20 @@ int vectorScan(char * file, int* n, double**pp){
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if defined (__APPLE__) || (__FreeBSD__)
+#if defined (__APPLE__) || (__FreeBSD__) || defined(NO_RANDOM_R)
 /* FreeBSD and Mac OS X do not provide random_r(), thread safety cannot be
    guaranteed.
    For FreeBSD and Mac OS X, nrand48() is much better than random().
    See: http://www.evanjones.ca/random-thread-safe.html
 */
-#pragma message "randomVector is not thread-safe in OSX and FreeBSD"
+#pragma message "randomVector is not thread-safe in OSX and FreeBSD or with NO_RANDOM_R"
 #endif
 
-#if defined (__APPLE__) || (__FreeBSD__) || defined(_WIN32) || defined(WIN32)
+#if defined (__APPLE__) || (__FreeBSD__) || defined(NO_RANDOM_R) || defined(_WIN32) || defined(WIN32)
 /* Windows use thread-safe random
    See: http://stackoverflow.com/questions/143108/is-windows-rand-s-thread-safe
 */
-#if defined (__APPLE__) || (__FreeBSD__)
+#if defined (__APPLE__) || (__FreeBSD__) || defined(NO_RANDOM_R)
 
 inline double urandom() {
     /* the probalility of matching will be theoretically p^3(in fact, it is not)


### PR DESCRIPTION
This allows building hmatrix against the musl libc, which allows easily linking Haskell programs statically.

`hmatrix` is one of the few packages that don't support this yet.

See https://github.com/NixOS/nixpkgs/issues/43795.