### PR TITLE
Export Precision type and constructors where they are needed

### DIFF
--- a/packages/special/lib/Numeric/GSL/Special/Bessel.hs
+++ b/packages/special/lib/Numeric/GSL/Special/Bessel.hs
@@ -106,6 +106,7 @@ module Numeric.GSL.Special.Bessel(
 , bessel_zero_J1
 , bessel_zero_Jnu_e
 , bessel_zero_Jnu
+, Precision(..)
 ) where
 
 import Foreign(Ptr)

--- a/packages/special/lib/Numeric/GSL/Special/Ellint.hs
+++ b/packages/special/lib/Numeric/GSL/Special/Ellint.hs
@@ -38,6 +38,7 @@ module Numeric.GSL.Special.Ellint(
 , ellint_RF
 , ellint_RJ_e
 , ellint_RJ
+, Precision(..)
 ) where
 
 import Foreign(Ptr)


### PR DESCRIPTION
It seemed to me that the `Precision` type and constructors should maybe be re-exported in the `Numeric.GSL.Special.Ellint` and `Numeric.GSL.Special.Bessel` modules. Some functions in those modules cannot be used without `Precision` type constructors. These constructors are currently re-exported in the Airy module, but given the current documentation it is difficult for new users to know that. 

Apologies if I am missing something here; I am new to Haskell, but from a new user perspective it seemed desirable to export the `Precision` type with the functions that require it. Maybe there is a better way though; like a separate "Types" module?