### PR TITLE
Fixed bug in 'vconcat'/'#' that does not properly re-expand zero-length vectors

### DIFF
--- a/packages/base/src/Internal/Static.hs
+++ b/packages/base/src/Internal/Static.hs
@@ -131,9 +131,9 @@ vconcat :: forall n m t . (KnownNat n, KnownNat m, Numeric t)
   where
     du = fromIntegral . natVal $ (undefined :: Proxy n)
     dv = fromIntegral . natVal $ (undefined :: Proxy m)
-    u' | du > 1 && LA.size u == 1 = LA.konst (u D.@> 0) du
+    u' | du /= 1 && LA.size u == 1 = LA.konst (u D.@> 0) du
        | otherwise = u
-    v' | dv > 1 && LA.size v == 1 = LA.konst (v D.@> 0) dv
+    v' | dv /= 1 && LA.size v == 1 = LA.konst (v D.@> 0) dv
        | otherwise = v
 
 


### PR DESCRIPTION
Previously:

```
extract $ ((1 :: R 1) # (2 :: R 0) :: R 1)
= [1, 2]
```

Because the `2` comes from `konst`, it is represented internally as a single-item vector.  `vconcat`, which is the main function implementing `#`, converts the single-item vector back into the full sized vector before concatenation.

However, the re-conversion back into a full sized vector did not handle the 0 case properly, only handling positive numbers properly.  This PR fixes the handling, so 

```
extract $ ((1 :: R 1) # (2 :: R 0) :: R 1)
= [1]
```

This fixes mstksg/hmatrix-backprop#1