### PR TITLE
Don't drop empty rows in mkCSR and mkSparse

### DIFF
--- a/packages/base/src/Internal/CG.hs
+++ b/packages/base/src/Internal/CG.hs
@@ -179,9 +179,9 @@ instance Testable GMatrix
           where
             m1 = convomat n k
             m2 = map (((+n) *** id) *** id) m1
-            
+
         testb n = vect $ take n $ cycle ([0..10]++[9,8..1])
-        
+
         denseSolve a = flatten . linearSolveLS a . asColumn
 
         -- mkDiag v = mkDiagR (dim v) (dim v) v


### PR DESCRIPTION
The previous implementation would forget the actual row numbers and assume that they were sequential.

We now keep the actual row numbers, and space the column positions with the distance between the rows.

This was a pretty quick hack together. I think this whole function could still actually be improved, as it's pretty unreadable and can still give incorrect answers if the same coordinates are declared twice.

Fixes #220 
Fixes #320 
