### PR TITLE
Remove extra warnings

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -29,21 +29,21 @@ extra-source-files: src/Internal/C/lapack-aux.h
 flag openblas
     description:    Link with OpenBLAS (https://github.com/xianyi/OpenBLAS) optimized libraries.
     default:        False
-    manual: True
+    manual:         True
 
 flag disable-default-paths
     description:    When enabled, don't add default hardcoded include/link dirs by default. Needed for hermetic builds like in nix.
     default:        False
-    manual: True
+    manual:         True
 
 flag no-random_r
     description:    When enabled, don't depend on the random_r() C function.
     default:        False
-    manual: True
+    manual:         True
 
 library
 
-    Build-Depends:      base >= 4.9 && < 5,
+    Build-Depends:      base >= 4.8 && < 5,
                         binary,
                         array,
                         deepseq,

--- a/packages/base/src/Internal/Algorithms.hs
+++ b/packages/base/src/Internal/Algorithms.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}

--- a/packages/base/src/Internal/Container.hs
+++ b/packages/base/src/Internal/Container.hs
@@ -3,9 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
-{-# OPTIONS_GHC -fno-warn-simplifiable-class-constraints #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -190,7 +187,7 @@ instance Container Vector e => Build Int (e -> e) Vector e
   where
     build = build'
 
-instance Container Matrix e => Build (Int,Int) (e -> e -> e) Matrix e
+instance (Num e, Container Vector e) => Build (Int,Int) (e -> e -> e) Matrix e
   where
     build = build'
 

--- a/packages/base/src/Internal/Conversion.hs
+++ b/packages/base/src/Internal/Conversion.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/packages/base/src/Internal/Element.hs
+++ b/packages/base/src/Internal/Element.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -40,7 +39,7 @@ import Foreign.C.Types(CInt)
 
 import Data.Binary
 
-instance (Binary (Vector a), Element a) => Binary (Matrix a) where
+instance (Binary a, Element a) => Binary (Matrix a) where
     put m = do
             put (cols m)
             put (flatten m)

--- a/packages/base/src/Internal/Modular.hs
+++ b/packages/base/src/Internal/Modular.hs
@@ -1,19 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies  #-}
 {-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# OPTIONS_GHC -fno-warn-missing-methods #-}
 
 {- |
 Module      :  Internal.Modular
@@ -150,6 +145,7 @@ instance KnownNat m => Element (Mod m I)
     gemm u a b c = gemmg (c_gemmMI m') (f2i u) (f2iM a) (f2iM b) (f2iM c)
       where
         m' = fromIntegral . natVal $ (undefined :: Proxy m)
+    reorderV strides dims = i2f . reorderAux c_reorderI strides dims . f2i
 
 instance KnownNat m => Element (Mod m Z)
   where
@@ -167,6 +163,7 @@ instance KnownNat m => Element (Mod m Z)
     gemm u a b c = gemmg (c_gemmML m') (f2i u) (f2iM a) (f2iM b) (f2iM c)
       where
         m' = fromIntegral . natVal $ (undefined :: Proxy m)
+    reorderV strides dims = i2f . reorderAux c_reorderL strides dims . f2i
 
 
 instance KnownNat m => CTrans (Mod m I)

--- a/packages/base/src/Internal/Modular.hs
+++ b/packages/base/src/Internal/Modular.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies  #-}
 {-# LANGUAGE TypeOperators #-}
@@ -83,11 +82,11 @@ instance (Ord t, KnownNat m) => Ord (Mod m t)
   where
     compare a b = compare (unMod a) (unMod b)
 
-instance (Integral t, Real t, KnownNat m, Integral (Mod m t)) => Real (Mod m t)
+instance (Integral t, Real t, KnownNat m) => Real (Mod m t)
   where
     toRational x = toInteger x % 1
 
-instance (Integral t, KnownNat m, Num (Mod m t)) => Integral (Mod m t)
+instance (Integral t, KnownNat m) => Integral (Mod m t)
   where
     toInteger = toInteger . unMod
     quotRem a b = (Mod q, Mod r)
@@ -95,7 +94,7 @@ instance (Integral t, KnownNat m, Num (Mod m t)) => Integral (Mod m t)
          (q,r) = quotRem (unMod a) (unMod b)
 
 -- | this instance is only valid for prime m
-instance (Show (Mod m t), Num (Mod m t), Eq t, KnownNat m) => Fractional (Mod m t)
+instance (Integral t, Show t, Eq t, KnownNat m) => Fractional (Mod m t)
   where
     recip x
         | x*r == 1  = r

--- a/packages/base/src/Internal/Static.hs
+++ b/packages/base/src/Internal/Static.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# OPTIONS_GHC -fno-warn-simplifiable-class-constraints #-}
 
 {- |
 Module      :  Internal.Static
@@ -367,7 +366,7 @@ instance (Num (Vector t), Numeric t )=> Num (Dim n (Vector t))
     negate = lift1F negate
     fromInteger x = Dim (fromInteger x)
 
-instance (Num (Vector t), Num (Matrix t), Fractional t, Numeric t) => Fractional (Dim n (Vector t))
+instance (Num (Vector t), Fractional t, Numeric t) => Fractional (Dim n (Vector t))
   where
     fromRational x = Dim (fromRational x)
     (/) = lift2F (/)
@@ -392,7 +391,7 @@ instance (Fractional t, Floating (Vector t), Numeric t) => Floating (Dim n (Vect
     pi    = Dim pi
 
 
-instance (Num (Matrix t), Numeric t) => Num (Dim m (Dim n (Matrix t)))
+instance (Num (Vector t), Numeric t) => Num (Dim m (Dim n (Matrix t)))
   where
     (+) = (lift2F . lift2F) (+)
     (*) = (lift2F . lift2F) (*)
@@ -402,12 +401,12 @@ instance (Num (Matrix t), Numeric t) => Num (Dim m (Dim n (Matrix t)))
     negate = (lift1F . lift1F) negate
     fromInteger x = Dim (Dim (fromInteger x))
 
-instance (Num (Vector t), Num (Matrix t), Fractional t, Numeric t) => Fractional (Dim m (Dim n (Matrix t)))
+instance (Num (Vector t), Fractional t, Numeric t) => Fractional (Dim m (Dim n (Matrix t)))
   where
     fromRational x = Dim (Dim (fromRational x))
     (/) = (lift2F.lift2F) (/)
 
-instance (Num (Vector t), Floating (Matrix t), Fractional t, Numeric t) => Floating (Dim m (Dim n (Matrix t))) where
+instance (Floating (Vector t), Floating t, Numeric t) => Floating (Dim m (Dim n (Matrix t))) where
     sin   = (lift1F . lift1F) sin
     cos   = (lift1F . lift1F) cos
     tan   = (lift1F . lift1F) tan


### PR DESCRIPTION
Simplifiable class constraints is stopping 7.10 builds #108, but it's an easy fix.

I've also implemented a few methods and turned off the warning suppression.
