### PR TITLE
Eliminate various GHC warnings

### DIFF
--- a/packages/base/src/Internal/Algorithms.hs
+++ b/packages/base/src/Internal/Algorithms.hs
@@ -26,6 +26,10 @@ module Internal.Algorithms (
   UpLo(..)
 ) where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
+
 import Internal.Vector
 import Internal.Matrix
 import Internal.Element
@@ -1158,4 +1162,3 @@ instance Field t => Additive (Herm t) where
 --   for usage in 'chol', 'eigSH', etc. Only a triangular part of the matrix will be used.
 trustSym :: Matrix t -> Herm t
 trustSym x = (Herm x)
-

--- a/packages/base/src/Internal/Util.hs
+++ b/packages/base/src/Internal/Util.hs
@@ -417,7 +417,7 @@ instance Indexable (Vector (Complex Float)) (Complex Float)
 
 instance Element t => Indexable (Matrix t) (Vector t)
   where
-    m!j = subVector (j*c) c (flatten m)
+    m ! j = subVector (j*c) c (flatten m)
       where
         c = cols m
 
@@ -912,4 +912,3 @@ test = (and ok, return ())
          , remap r (tr c) p == ep
          , tr p ?? (PosCyc (idxs[-5,13]), Pos (idxs[3,7,1])) == (2><3) [35,75,15,33,73,13]
          ]
-


### PR DESCRIPTION
The proposed changes eliminate the following warnings:
```
hmatrix         > src\Internal\Algorithms.hs:945:11: warning: [-Wname-shadowing]
hmatrix         >     This binding for `<>' shadows the existing binding
hmatrix         >       imported from `Prelude' at src\Internal\Algorithms.hs:24:8-26
hmatrix         >       (and originally defined in `GHC.Base')
hmatrix         >     |
hmatrix         > 945 |           (<>) = multiply
hmatrix         >     |           ^^^^
hmatrix         >
hmatrix         > src\Internal\Algorithms.hs:1126:5: warning: [-Wname-shadowing]
hmatrix         >     This binding for `<>' shadows the existing binding
hmatrix         >       imported from `Prelude' at src\Internal\Algorithms.hs:24:8-26
hmatrix         >       (and originally defined in `GHC.Base')
hmatrix         >      |
hmatrix         > 1126 |     (<>) = mXm
hmatrix         >      |     ^^^^
```
and
```
hmatrix         > src\Internal\Util.hs:420:6: warning: [-Wmissing-space-after-bang]
hmatrix         >     Did you forget to enable BangPatterns?
hmatrix         >     If you mean to bind (!) then perhaps you want
hmatrix         >     to add a space after the bang for clarity.
hmatrix         >     |
hmatrix         > 420 |     m!j = subVector (j*c) c (flatten m)
hmatrix         >     |      ^^
```