### PR TITLE
Fix #328 Update README for SUNDIALS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Haskell library for numerical computation
 
 A purely functional interface to linear algebra and other numerical
 algorithms, internally implemented using [LAPACK][lapack],
-[BLAS][blas], [GSL][gsl] and [SUNDIALS][sundials].
+[BLAS][blas], [GSL][gsl] and [GLPK][glpk].
 
 This package includes matrix decompositions (eigensystems, singular
 values, Cholesky, QR, etc.), linear solvers, numeric integration, root
@@ -13,30 +13,29 @@ finding, etc.
   intended to be a breaking change but a lot of modules have been
   modified to ensure that continuous integration is green.
 
-- Support for SUNDIALS has been added. It should be possible to
-  replace Numeric.GSL.ODE with Numeric.Sundials.ARKode.ODE and have
-  your program work as before bearing in mind that the methods and
-  error control might differ (even for those with the same names!).
-
 - [Code examples][examples]
 
 - Source code and documentation (Hackage)
-    - linear algebra: [hmatrix](http://hackage.haskell.org/package/hmatrix)
-    - numeric algorithms: [hmatrix-gsl](http://hackage.haskell.org/package/hmatrix-gsl)
-    - special functions: [hmatrix-special](http://hackage.haskell.org/package/hmatrix-special)
-    - linear programming: [hmatrix-glpk](http://hackage.haskell.org/package/hmatrix-glpk)
+    - linear algebra: [hmatrix][hmatrix]
+    - numeric algorithms: [hmatrix-gsl][hmatrix-gsl]
+    - special functions: [hmatrix-special][hmatrix-special]
+    - linear programming: [hmatrix-glpk][hmatrix-glpk]
 
 - [Tutorial (old version)][tutorial]
 
 - [Installation help][installation]
 
+For numerical algorithms internally implemented using [SUNDIALS][sundials], see
+package [hmatrix-sundials] and its separate respository.
+
 Contributions, suggestions, and bug reports are welcome!
 
 
 
-[lapack]: http://www.netlib.org/lapack/
-[blas]: http://www.netlib.org/blas/
-[gsl]: http://www.gnu.org/software/gsl/
+[lapack]: https://www.netlib.org/lapack/
+[blas]: https://www.netlib.org/blas/
+[glpk]: https://www.gnu.org/software/glpk/
+[gsl]: https://www.gnu.org/software/gsl/
 [sundials]: https://computation.llnl.gov/projects/sundials
 
 [tutorial]: http://dis.um.es/profesores/alberto/material/hmatrix.pdf
@@ -44,17 +43,20 @@ Contributions, suggestions, and bug reports are welcome!
 [changes]: https://github.com/albertoruiz/hmatrix/tree/master/packages/base/CHANGELOG
 [examples]: http://dis.um.es/~alberto/hmatrix/hmatrix.html
 
-
-[hmatrix-static]: http://hackage.haskell.org/package/hmatrix-static
+[hmatrix]: https://hackage.haskell.org/package/hmatrix
+[hmatrix-glpk]: https://hackage.haskell.org/package/hmatrix-glpk
+[hmatrix-gsl]: https://hackage.haskell.org/package/hmatrix-gsl
+[hmatrix-gsl-stats]: https://hackage.haskell.org/package/hmatrix-gsl-stats
+[hmatrix-special]: https://hackage.haskell.org/package/hmatrix-special
+[hmatrix-static]: https://hackage.haskell.org/package/hmatrix-static
+[hmatrix-sundials]: https://hackage.haskell.org/package/hmatrix-sundials
+[hstatistics]: https://hackage.haskell.org/package/hstatistics
+[hsignal]: https://hackage.haskell.org/package/hsignal
 [hTensor]: https://github.com/AlbertoRuiz/hTensor
-[hmatrix-gsl-stats]: http://hackage.haskell.org/package/hmatrix-gsl-stats
-[hstatistics]: http://hackage.haskell.org/package/hstatistics
-[hsignal]: http://hackage.haskell.org/package/hsignal
-[pBLAS]: http://hackage.haskell.org/package/blas
-[pLAPACK]: http://github.com/patperry/lapack
-[aGSL]: http://hackage.haskell.org/package/bindings-gsl
-[nprelude]: http://hackage.haskell.org/package/numeric-prelude
-[mathHack]: http://hackage.haskell.org/packages/#cat:Math
+[pBLAS]: https://hackage.haskell.org/package/blas
+[pLAPACK]: https://github.com/patperry/lapack
+[aGSL]: https://hackage.haskell.org/package/bindings-gsl
+[nprelude]: https://hackage.haskell.org/package/numeric-prelude
+[mathHack]: https://hackage.haskell.org/packages/#cat:Math
 [easyVision]: https://github.com/AlbertoRuiz/easyVision
-[repa]: http://hackage.haskell.org/package/repa
-
+[repa]: https://hackage.haskell.org/package/repa


### PR DESCRIPTION
Also replaces http with https where applicable and takes a consistent approach to using Markdown reference-style links.