### PR TITLE
Existential wrappers for the static vectors and matrices are added

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/develop.nix
+++ b/develop.nix
@@ -1,0 +1,29 @@
+{ pkgs }: with pkgs; let
+
+  ghcCharged =  haskellPackages.ghcWithPackages (p: with p; [
+                  haskell-language-server
+                  ghcid
+                ]);
+  ghcid-bin = haskellPackages.ghcid.bin;
+
+  ghcid-bin-with-openblas = let
+    ghcid = "${ghcid-bin}/bin/ghcid";
+    out = "$out/bin/ghcid";
+  in runCommand "ghcid" { buildInputs = [ makeWrapper ]; } ''
+    makeWrapper ${ghcid} ${out} --add-flags \
+      "--command='cd packages/base && \
+                    cabal repl lib:hmatrix \
+                    --flags=openblas \
+                    --extra-lib-dirs=${openblasCompat}/lib \
+                    --extra-include-dir=${openblasCompat}/include \
+                 '"
+  '';
+
+in mkShell {
+  buildInputs =  haskellPackages.hmatrix.env.nativeBuildInputs ++
+                 [ ghcCharged
+                   ghcid-bin-with-openblas
+                   cabal-install
+                   openblasCompat
+                 ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "haedosa": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1644072384,
+        "narHash": "sha256-iFZhwOlVnDIfi8dPkuN07ggaFID69iJy24LM1rodzIE=",
+        "owner": "haedosa",
+        "repo": "flakes",
+        "rev": "ef07b11388d5d0c7db9ba610392102bb8cd39d58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haedosa",
+        "repo": "flakes",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "haedosa",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1643933536,
+        "narHash": "sha256-yRmsWAG4DnLxLIUtlaZsl0kH7rN5xSoyNRlf0YZrcH4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "2860d7e3bb350f18f7477858f3513f9798896831",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-21.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643788601,
+        "narHash": "sha256-6l5Ax44pC/Oo/Muj5Y/NA27Pd38Wty/7GtGSSmYNug4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6ddd55d5f9d5eca08df138c248008c1ba73ecec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": [
+          "haedosa",
+          "flake-utils"
+        ],
+        "haedosa": "haedosa",
+        "nixpkgs": [
+          "haedosa",
+          "nixpkgs"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "hmatrix";
+
+  inputs = {
+
+    haedosa.url = "github:haedosa/flakes";
+    nixpkgs.follows = "haedosa/nixpkgs";
+    flake-utils.follows = "haedosa/flake-utils";
+
+  };
+
+  outputs =
+    inputs@{ self, nixpkgs, flake-utils, ... }:
+    {
+      overlay = nixpkgs.lib.composeManyExtensions (
+                  [ (import ./overlay.nix)
+                  ]);
+
+    } // flake-utils.lib.eachDefaultSystem (system:
+
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = { allowUnfree = true; };
+          overlays = [ self.overlay ];
+        };
+      in rec {
+
+        devShell = import ./develop.nix { inherit pkgs; };
+
+        defaultPackage = pkgs.haskellPackages.hmatrix;
+        packages = {
+          hmatrix = pkgs.haskellPackages.hmatrix;
+          hmatrix-glpk = pkgs.haskellPackages.hmatrix-glpk;
+          hmatrix-gsl = pkgs.haskellPackages.hmatrix-gsl;
+          hmatrix-sparse = pkgs.haskellPackages.hmatrix-sparse;
+          hmatrix-special = pkgs.haskellPackages.hmatrix-special;
+          hmatrix-tests = pkgs.haskellPackages.hmatrix-tests;
+        };
+
+      }
+    );
+
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,17 @@
+final: prev: with final; {
+
+  haskellPackages = prev.haskellPackages.override (old: {
+    overrides = lib.composeManyExtensions [
+                  (old.overrides or (_: _: {}))
+                  (haskell.lib.packageSourceOverrides {
+                    hmatrix = ./packages/base;
+                    hmatrix-glpk = ./packages/glpk;
+                    hmatrix-gsl = ./packages/gsl;
+                    hmatrix-sparse = ./packages/sparse;
+                    hmatrix-special = ./packages/special;
+                    hmatrix-tests = ./packages/tests;
+                  })
+                ];
+  });
+
+}

--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -56,7 +56,8 @@ library
                         storable-complex,
                         semigroups,
                         finite-typelits,
-                        vector >= 0.11
+                        vector >= 0.11,
+                        mtl
 
     hs-source-dirs:     src
 

--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -65,8 +65,6 @@ library
                         Numeric.LinearAlgebra.Data
                         Numeric.LinearAlgebra.HMatrix
                         Numeric.LinearAlgebra.Static
-                        Numeric.LinearAlgebra.Static.Real
-                        Numeric.LinearAlgebra.Static.Complex
 
     other-modules:      Internal.Vector
                         Internal.Devel
@@ -90,6 +88,8 @@ library
                         Internal.Util
                         Internal.Modular
                         Internal.Static
+                        Internal.Static.Real
+                        Internal.Static.Complex
 
     C-sources:          src/Internal/C/lapack-aux.c
                         src/Internal/C/vector-aux.c

--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -55,6 +55,7 @@ library
                         primitive,
                         storable-complex,
                         semigroups,
+                        finite-typelits,
                         vector >= 0.11
 
     hs-source-dirs:     src
@@ -64,6 +65,8 @@ library
                         Numeric.LinearAlgebra.Data
                         Numeric.LinearAlgebra.HMatrix
                         Numeric.LinearAlgebra.Static
+                        Numeric.LinearAlgebra.Static.Real
+                        Numeric.LinearAlgebra.Static.Complex
 
     other-modules:      Internal.Vector
                         Internal.Devel

--- a/packages/base/src/Internal/Static/Complex.hs
+++ b/packages/base/src/Internal/Static/Complex.hs
@@ -28,42 +28,7 @@ See code examples at http://dis.um.es/~alberto/hmatrix/static.html.
 
 -}
 
-module Numeric.LinearAlgebra.Static.Complex(
-    -- * Vector
-       ℝ, R,
-    vec2, vec3, vec4, (&), (#), split, headTail,
-    vector,
-    linspace, range, dim,
-    -- * Matrix
-    L, Sq, build,
-    row, col, (|||),(===), splitRows, splitCols,
-    unrow, uncol,
-    tr,
-    eye,
-    diag, diagR,
-    blockAt,
-    matrix,
-    -- * Complex
-    ℂ, C, M,
-    -- * Products
-    (<>),(#>),(<.>),(<·>),
-    mul, app, dot,
-    -- * Linear Systems
-    linSolve, (<\>),
-    -- * Factorizations
-    withCompactSVD,
-    withNullspace, withOrth, qr,
-    -- * Misc
-    mean,
-    Disp(..),
-    cross, outer, mapC, mapM, det, zipWith,
-    invlndet, expm, sqrtm, inv,
-    isKonst, isKonstV,
-    withVector, withMatrix, exactLength, exactDims,
-    toRows, toColumns, withRows, withColumns,
-    flatten, reshape,
-    Sized(..),
-) where
+module Internal.Static.Complex where
 
 
 import GHC.TypeLits

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -449,6 +449,12 @@ instance KnownNat n => Eigen (Sq n) (C n) (M n n)
       where
         (l,v) = LA.eig m
 
+instance KnownNat n => Eigen (M n n) (C n) (M n n)
+  where
+    eigenvalues (extract -> m) = mkC . LA.eigenvalues $ m
+    eigensystem (extract -> m) = (mkC l, mkM v)
+      where
+        (l,v) = LA.eig m
 
 --------------------------------------------------------------------------------
 

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -13,9 +13,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoStarIsType #-}
 
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- |
 Module      :  Numeric.LinearAlgebra.Static
@@ -32,18 +31,9 @@ See code examples at http://dis.um.es/~alberto/hmatrix/static.html.
 module Numeric.LinearAlgebra.Static(
     -- * Vector
        ℝ, R,
-    vec2, vec3, vec4, (&), (#), split, headTail,
-    vector,
-    linspace, range, dim,
     -- * Matrix
-    L, Sq, build,
-    row, col, (|||),(===), splitRows, splitCols,
-    unrow, uncol,
+    L, Sq,
     tr,
-    eye,
-    diag,
-    blockAt,
-    matrix,
     -- * Complex
     ℂ, C, M, Her, her, 𝑖,
     toComplex,
@@ -53,10 +43,6 @@ module Numeric.LinearAlgebra.Static(
     imag,
     sqMagnitude,
     magnitude,
-    -- * Products
-    (<>),(#>),(<.>),
-    -- * Linear Systems
-    linSolve, (<\>),
     -- * Factorizations
     svd, withCompactSVD, svdTall, svdFlat, Eigen(..),
     withNullspace, withOrth, qr, chol,
@@ -66,11 +52,8 @@ module Numeric.LinearAlgebra.Static(
     Seed, RandDist(..),
     randomVector, rand, randn, gaussianSample, uniformSample,
     -- * Misc
-    mean, meanCov,
     Disp(..), Domain(..),
-    withVector, withMatrix, exactLength, exactDims,
-    toRows, toColumns, withRows, withColumns,
-    Sized(..), Diag(..), Sym, sym, mTm, unSym, (<·>)
+    Sized(..), Diag(..), Sym, sym, mTm, unSym,
 ) where
 
 
@@ -82,161 +65,252 @@ import Numeric.LinearAlgebra hiding (
     eigenvalues,eigenvaluesSH,build,
     qr,size,dot,chol,range,R,C,sym,mTm,unSym,
     randomVector,rand,randn,gaussianSample,uniformSample,meanCov,
-    toComplex, fromComplex, complex, real, magnitude
+    toComplex, fromComplex, complex, real, magnitude, diag
     )
 import qualified Numeric.LinearAlgebra as LA
-import qualified Numeric.LinearAlgebra.Devel as LA
+import qualified Numeric.LinearAlgebra.Static.Real as R
+import qualified Numeric.LinearAlgebra.Static.Complex as C
 import Data.Proxy(Proxy(..))
 import Internal.Static
-import Control.Arrow((***))
 import Text.Printf
-import Data.Type.Equality ((:~:)(Refl))
-import qualified Data.Bifunctor as BF (first)
 #if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
+import Data.Finite (Finite)
 #endif
 
-ud1 :: R n -> Vector ℝ
-ud1 (R (Dim v)) = v
 
-
-infixl 4 &
-(&) :: forall n . KnownNat n
-    => R n -> ℝ -> R (n+1)
-u & x = u # (konst x :: R 1)
-
-infixl 4 #
-(#) :: forall n m . (KnownNat n, KnownNat m)
-    => R n -> R m -> R (n+m)
-(R u) # (R v) = R (vconcat u v)
-
-
-
-vec2 :: ℝ -> ℝ -> R 2
-vec2 a b = R (gvec2 a b)
-
-vec3 :: ℝ -> ℝ -> ℝ -> R 3
-vec3 a b c = R (gvec3 a b c)
-
-
-vec4 :: ℝ -> ℝ -> ℝ -> ℝ -> R 4
-vec4 a b c d = R (gvec4 a b c d)
-
-vector :: KnownNat n => [ℝ] -> R n
-vector = fromList
-
-matrix :: (KnownNat m, KnownNat n) => [ℝ] -> L m n
-matrix = fromList
-
-linspace :: forall n . KnownNat n => (ℝ,ℝ) -> R n
-linspace (a,b) = v
+class Domain field vec mat | mat -> vec field, vec -> mat field, field -> mat vec
   where
-    v = mkR (LA.linspace (size v) (a,b))
 
-range :: forall n . KnownNat n => R n
-range = v
-  where
-    v = mkR (LA.linspace d (1,fromIntegral d))
-    d = size v
+    mul :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => mat m k -> mat k n -> mat m n
+    app :: forall m n . (KnownNat m, KnownNat n) => mat m n -> vec n -> vec m
+    dot :: forall n . (KnownNat n) => vec n -> vec n -> field
+    infixr 8 <>
+    (<>) :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => mat m k -> mat k n -> mat m n
+    infixr 8 #>
+    (#>) :: (KnownNat m, KnownNat n) => mat m n -> vec n -> vec m
+    infixr 8 <·>
+    (<·>) :: KnownNat n => vec n -> vec n -> field
+    infixr 8 <.>
+    (<.>) :: KnownNat n => vec n -> vec n -> field
 
-dim :: forall n . KnownNat n => R n
-dim = v
-  where
-    v = mkR (scalar (fromIntegral $ size v))
+    cross :: vec 3 -> vec 3 -> vec 3
+    diag ::  forall n . KnownNat n => vec n -> mat n n
+    diagR ::  forall m n k . (KnownNat m, KnownNat n, KnownNat k) => field -> vec k -> mat m n
+    eye :: forall n. KnownNat n => mat n n
+    dvmap :: forall n. KnownNat n => (field -> field) -> vec n -> vec n
+    dmmap :: forall n m. (KnownNat m, KnownNat n) => (field -> field) -> mat n m -> mat n m
+    outer :: forall n m. (KnownNat m, KnownNat n) => vec n -> vec m -> mat n m
+    zipWithVector :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
+
+    isKonst :: forall m n . (KnownNat m, KnownNat n) => mat m n -> Maybe (field,(Int,Int))
+    isKonstV :: forall n . KnownNat n => vec n -> Maybe (field,Int)
+
+    vector :: KnownNat n => [field] -> vec n
+    matrix :: (KnownNat m, KnownNat n) => [field] -> mat m n
+    split :: forall p n . (KnownNat p, KnownNat n, p<=n) => vec n -> (vec p, vec (n-p))
+    splitRows :: forall p m n . (KnownNat p, KnownNat m, KnownNat n, p<=m) => mat m n -> (mat p n, mat (m-p) n)
+    splitCols :: forall p m n. (KnownNat p, KnownNat m, KnownNat n, KnownNat (n-p), p<=n) => mat m n -> (mat m p, mat m (n-p))
+    headTail :: (KnownNat n, 1<=n) => vec n -> (field, vec (n-1))
+
+    toRows :: forall m n . (KnownNat m, KnownNat n) => mat m n -> [vec n]
+    withRows :: forall n z . KnownNat n => [vec n] -> (forall m . KnownNat m => mat m n -> z) -> z
+    toColumns :: forall m n . (KnownNat m, KnownNat n) => mat m n -> [vec m]
+    withColumns :: forall m z . KnownNat m => [vec m] -> (forall n . KnownNat n => mat m n -> z) -> z
+
+    det :: forall n. KnownNat n => mat n n -> field
+    invlndet :: forall n. KnownNat n => mat n n -> (mat n n, (field, field))
+    expm :: forall n. KnownNat n => mat n n -> mat n n
+    sqrtm :: forall n. KnownNat n => mat n n -> mat n n
+    inv :: forall n. KnownNat n => mat n n -> mat n n
+    infixl 7 <\>
+    (<\>) :: (KnownNat m, KnownNat n, KnownNat r) => mat m n -> mat m r -> mat n r
+    linSolve :: (KnownNat m, KnownNat n) => mat m m -> mat m n -> Maybe (mat m n)
+
+    build :: forall m n . (KnownNat n, KnownNat m) => (field -> field -> field) -> mat m n
+    vec2 :: field -> field -> vec 2
+    vec3 :: field -> field -> field -> vec 3
+    vec4 :: field -> field -> field -> field -> vec 4
+    row :: KnownNat n => vec n -> mat 1 n
+    unrow :: KnownNat n => mat 1 n -> vec n
+    col :: KnownNat n => vec n -> mat n 1
+    uncol :: KnownNat n => mat n 1 -> vec n
+    infixl 2 ===
+    (===) :: (KnownNat r1, KnownNat r2, KnownNat c) => mat r1 c -> mat r2 c -> mat (r1+r2) c
+    (|||) :: (KnownNat r, KnownNat c1, KnownNat c2, KnownNat (c1+c2)) => mat r c1 -> mat r c2 -> mat r (c1+c2)
+    infixl 4 #
+    (#) :: forall n m . (KnownNat n, KnownNat m) => vec n -> vec m -> vec (n+m)
+    infixl 4 &
+    (&) :: forall n . KnownNat n => vec n -> field -> vec (n+1)
+    flatten :: (KnownNat m, KnownNat n, KnownNat (m * n)) => mat m n -> vec (m * n)
+    reshape :: (KnownNat m, KnownNat n, KnownNat k, n ~ (k * m)) => vec n -> mat k m
+
+    linspace :: forall n . KnownNat n => (field,field) -> vec n
+    range :: forall n . KnownNat n => vec n
+    dim :: forall n . KnownNat n => vec n
+    mean :: (KnownNat n, 1<=n) => vec n -> field
+
+    withVector :: forall z . Vector field -> (forall n . (KnownNat n) => vec n -> z) -> z
+    exactLength :: forall n m . (KnownNat n, KnownNat m) => vec m -> Maybe (vec n)
+    withMatrix :: forall z . Matrix field -> (forall m n . (KnownNat m, KnownNat n) => mat m n -> z) -> z
+    exactDims :: forall n m j k . (KnownNat n, KnownNat m, KnownNat j, KnownNat k) => mat m n -> Maybe (mat j k)
+
+    blockAt :: forall m n . (KnownNat m, KnownNat n) => field -> Int -> Int -> Matrix field -> mat m n
+
+    vAt :: forall n. KnownNat n => vec n -> Finite n -> field
+    mAt :: forall m n. (KnownNat m, KnownNat n) => mat m n -> Finite m -> Finite n -> field
 
 --------------------------------------------------------------------------------
 
-
-ud2 :: L m n -> Matrix ℝ
-ud2 (L (Dim (Dim x))) = x
-
-
---------------------------------------------------------------------------------
-
-diag :: KnownNat n => R n -> Sq n
-diag = diagR 0
-
-eye :: KnownNat n => Sq n
-eye = diag 1
-
---------------------------------------------------------------------------------
-
-blockAt :: forall m n . (KnownNat m, KnownNat n) =>  ℝ -> Int -> Int -> Matrix Double -> L m n
-blockAt x r c a = res
+instance Domain ℝ R L
   where
-    z = scalar x
-    z1 = LA.konst x (r,c)
-    z2 = LA.konst x (max 0 (m'-(ra+r)), max 0 (n'-(ca+c)))
-    ra = min (rows a) . max 0 $ m'-r
-    ca = min (cols a) . max 0 $ n'-c
-    sa = subMatrix (0,0) (ra, ca) a
-    (m',n') = size res
-    res = mkL $ fromBlocks [[z1,z,z],[z,sa,z],[z,z,z2]]
+    mul = R.mul
+    app = R.app
+    dot = R.dot
+    (<>) = mul
+    (#>) = app
+    (<·>) = dot
+    (<.>) = dot
+
+    cross = R.cross
+    diag  = R.diag
+    diagR = R.diagR
+    eye   = R.eye
+    dvmap = R.mapR
+    dmmap = R.mapL
+    outer = R.outer
+    zipWithVector = R.zipWith
+
+    isKonst = R.isKonst
+    isKonstV = R.isKonstV
+
+    vector = fromList
+    matrix = fromList
+    split = R.split
+    splitRows = R.splitRows
+    splitCols = R.splitCols
+    headTail = R.headTail
+
+    toRows = R.toRows
+    withRows = R.withRows
+    toColumns = R.toColumns
+    withColumns  = R.withColumns
+
+    det = R.det
+    invlndet = R.invlndet
+    expm = R.expm
+    sqrtm = R.sqrtm
+    inv = R.inv
+    (<\>) = (R.<\>)
+    linSolve = R.linSolve
+
+    build = R.build
+    vec2 = R.vec2
+    vec3 = R.vec3
+    vec4 = R.vec4
+    row = R.row
+    unrow = R.unrow
+    col = R.col
+    uncol = R.uncol
+    (===) = (R.===)
+    (|||) = (R.|||)
+    (#) = (R.#)
+    (&) = (R.&)
+    flatten = R.flatten
+    reshape = R.reshape
+
+    linspace = R.linspace
+    range = R.range
+    dim = R.dim
+    mean = R.mean
+
+    withVector  = R.withVector
+    exactLength = R.exactLength
+    withMatrix = R.withMatrix
+    exactDims = R.exactDims
+
+    blockAt = R.blockAt
+
+    vAt = R.vAt
+    mAt = R.mAt
+
+instance Domain ℂ C M
+  where
+    mul = C.mul
+    app = C.app
+    dot = C.dot
+    (<>) = mul
+    (#>) = app
+    (<·>) = dot
+    (<.>) = dot
+
+    cross = C.cross
+    diag  = C.diag
+    diagR = C.diagR
+    eye   = C.eye
+    dvmap = C.mapC
+    dmmap = C.mapM
+    outer = C.outer
+    zipWithVector = C.zipWith
+
+    isKonst = C.isKonst
+    isKonstV = C.isKonstV
+
+    vector = fromList
+    matrix = fromList
+    split = C.split
+    splitRows = C.splitRows
+    splitCols = C.splitCols
+    headTail = C.headTail
+
+    toRows = C.toRows
+    withRows = C.withRows
+    toColumns = C.toColumns
+    withColumns  = C.withColumns
+
+    det = C.det
+    invlndet = C.invlndet
+    expm = C.expm
+    sqrtm = C.sqrtm
+    inv = C.inv
+    (<\>) = (C.<\>)
+    linSolve = C.linSolve
+
+    build = C.build
+    vec2 = C.vec2
+    vec3 = C.vec3
+    vec4 = C.vec4
+    row = C.row
+    unrow = C.unrow
+    col = C.col
+    uncol = C.uncol
+    (===) = (C.===)
+    (|||) = (C.|||)
+    (#) = (C.#)
+    (&) = (C.&)
+    flatten = C.flatten
+    reshape = C.reshape
+
+    linspace = C.linspace
+    range = C.range
+    dim = C.dim
+    mean = C.mean
+
+    withVector  = C.withVector
+    exactLength = C.exactLength
+    withMatrix = C.withMatrix
+    exactDims = C.exactDims
+
+    blockAt = C.blockAt
+
+    vAt = C.vAt
+    mAt = C.mAt
+
 
 --------------------------------------------------------------------------------
-
-
-row :: R n -> L 1 n
-row = mkL . asRow . ud1
-
---col :: R n -> L n 1
-col v = tr . row $ v
-
-unrow :: L 1 n -> R n
-unrow = mkR . head . LA.toRows . ud2
-
---uncol :: L n 1 -> R n
-uncol v = unrow . tr $ v
-
-
-infixl 2 ===
-(===) :: (KnownNat r1, KnownNat r2, KnownNat c) => L r1 c -> L r2 c -> L (r1+r2) c
-a === b = mkL (extract a LA.=== extract b)
-
-
-infixl 3 |||
--- (|||) :: (KnownNat r, KnownNat c1, KnownNat c2) => L r c1 -> L r c2 -> L r (c1+c2)
-a ||| b = tr (tr a === tr b)
-
 
 type Sq n  = L n n
---type CSq n = CL n n
 
-
-type GL = forall n m . (KnownNat n, KnownNat m) => L m n
-type GSq = forall n . KnownNat n => Sq n
-
-isKonst :: forall m n . (KnownNat m, KnownNat n) => L m n -> Maybe (ℝ,(Int,Int))
-isKonst s@(unwrap -> x)
-    | singleM x = Just (x `atIndex` (0,0), (size s))
-    | otherwise = Nothing
-
-
-isKonstC :: forall m n . (KnownNat m, KnownNat n) => M m n -> Maybe (ℂ,(Int,Int))
-isKonstC s@(unwrap -> x)
-    | singleM x = Just (x `atIndex` (0,0), (size s))
-    | otherwise = Nothing
-
-
-infixr 8 <>
-(<>) :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => L m k -> L k n -> L m n
-(<>) = mulR
-
-
-infixr 8 #>
-(#>) :: (KnownNat m, KnownNat n) => L m n -> R n -> R m
-(#>) = appR
-
-
-infixr 8 <·>
-(<·>) :: KnownNat n => R n -> R n -> ℝ
-(<·>) = dotR
-
-infixr 8 <.>
-(<.>) :: KnownNat n => R n -> R n -> ℝ
-(<.>) = dotR
-
---------------------------------------------------------------------------------
 
 class Diag m d | m -> d
   where
@@ -252,22 +326,23 @@ instance KnownNat n => Diag (M n n) (C n)
   where
     takeDiag x = mkC (LA.takeDiag (extract x))
 
+
 --------------------------------------------------------------------------------
 
 
 toComplex :: KnownNat n => (R n, R n) -> C n
-toComplex (r,i) = mkC $ LA.toComplex (ud1 r, ud1 i)
+toComplex (r,i) = mkC $ LA.toComplex (extract r, extract i)
 
 fromComplex :: KnownNat n => C n -> (R n, R n)
 fromComplex (C (Dim v)) = let (r,i) = LA.fromComplex v in (mkR r, mkR i)
 
 complex :: KnownNat n => R n -> C n
-complex r = mkC $ LA.toComplex (ud1 r, LA.konst 0 (size r))
+complex r = mkC $ LA.toComplex (extract r, LA.konst 0 (size r))
 
 real :: KnownNat n => C n -> R n
 real = fst . fromComplex
 
-imag :: KnownNat n => C n -> R n 
+imag :: KnownNat n => C n -> R n
 imag = snd . fromComplex
 
 sqMagnitude :: KnownNat n => C n -> R n
@@ -276,13 +351,8 @@ sqMagnitude c = let (r,i) = fromComplex c in r**2 + i**2
 magnitude :: KnownNat n => C n -> R n
 magnitude = sqrt . sqMagnitude
 
+
 --------------------------------------------------------------------------------
-
-linSolve :: (KnownNat m, KnownNat n) => L m m -> L m n -> Maybe (L m n)
-linSolve (extract -> a) (extract -> b) = fmap mkL (LA.linearSolve a b)
-
-(<\>) :: (KnownNat m, KnownNat n, KnownNat r) => L m n -> L m r -> L n r
-(extract -> a) <\> (extract -> b) = mkL (a LA.<\> b)
 
 svd :: (KnownNat m, KnownNat n) => L m n -> (L m m, R n, L n n)
 svd (extract -> m) = (mkL u, mkR s', mkL v)
@@ -304,214 +374,6 @@ svdFlat (extract -> m) = (mkL u, mkR s, mkL v)
     (u,s,v) = LA.thinSVD m
 
 --------------------------------------------------------------------------------
-
-class Eigen m l v | m -> l, m -> v
-  where
-    eigensystem :: m -> (l,v)
-    eigenvalues :: m -> l
-
-newtype Sym n = Sym (Sq n) deriving Show
-
-
-sym :: KnownNat n => Sq n -> Sym n
-sym m = Sym $ (m + tr m)/2
-
-mTm :: (KnownNat m, KnownNat n) => L m n -> Sym n
-mTm x = Sym (tr x <> x)
-
-unSym :: Sym n -> Sq n
-unSym (Sym x) = x
-
-
-𝑖 :: Sized ℂ s c => s
-𝑖 = konst iC
-
-newtype Her n = Her (M n n)
-
-her :: KnownNat n => M n n -> Her n
-her m = Her $ (m + LA.tr m)/2
-
-
-instance (KnownNat n) => Disp (Sym n)
-  where
-    disp n (Sym x) = do
-        let a = extract x
-        let su = LA.dispf n a
-        printf "Sym %d" (cols a) >> putStr (dropWhile (/='\n') $ su)
-
-instance (KnownNat n) => Disp (Her n)
-  where
-    disp n (Her x) = do
-        let a = extract x
-        let su = LA.dispcf n a
-        printf "Her %d" (cols a) >> putStr (dropWhile (/='\n') $ su)
-
-
-instance KnownNat n => Eigen (Sym n) (R n) (L n n)
-  where
-    eigenvalues (Sym (extract -> m)) =  mkR . LA.eigenvaluesSH . LA.trustSym $ m
-    eigensystem (Sym (extract -> m)) = (mkR l, mkL v)
-      where
-        (l,v) = LA.eigSH . LA.trustSym $ m
-
-instance KnownNat n => Eigen (Sq n) (C n) (M n n)
-  where
-    eigenvalues (extract -> m) = mkC . LA.eigenvalues $ m
-    eigensystem (extract -> m) = (mkC l, mkM v)
-      where
-        (l,v) = LA.eig m
-
-chol :: KnownNat n => Sym n -> Sq n
-chol (extract . unSym -> m) = mkL $ LA.chol $ LA.trustSym m
-
---------------------------------------------------------------------------------
-
-withNullspace
-    :: forall m n z . (KnownNat m, KnownNat n)
-    => L m n
-    -> (forall k . (KnownNat k) => L n k -> z)
-    -> z
-withNullspace (LA.nullspace . extract -> a) f =
-    case someNatVal $ fromIntegral $ cols a of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
-
-withOrth
-    :: forall m n z . (KnownNat m, KnownNat n)
-    => L m n
-    -> (forall k. (KnownNat k) => L n k -> z)
-    -> z
-withOrth (LA.orth . extract -> a) f =
-    case someNatVal $ fromIntegral $ cols a of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
-
-withCompactSVD
-    :: forall m n z . (KnownNat m, KnownNat n)
-    => L m n
-    -> (forall k . (KnownNat k) => (L m k, R k, L n k) -> z)
-    -> z
-withCompactSVD (LA.compactSVD . extract -> (u,s,v)) f =
-    case someNatVal $ fromIntegral $ LA.size s of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy k)) -> f (mkL u :: L m k, mkR s :: R k, mkL v :: L n k)
-
---------------------------------------------------------------------------------
-
-qr :: (KnownNat m, KnownNat n) => L m n -> (L m m, L m n)
-qr (extract -> x) = (mkL q, mkL r)
-  where
-    (q,r) = LA.qr x
-
--- use qrRaw?
-
---------------------------------------------------------------------------------
-
-split :: forall p n . (KnownNat p, KnownNat n, p<=n) => R n -> (R p, R (n-p))
-split (extract -> v) = ( mkR (subVector 0 p' v) ,
-                         mkR (subVector p' (LA.size v - p') v) )
-  where
-    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
-
-
-headTail :: (KnownNat n, 1<=n) => R n -> (ℝ, R (n-1))
-headTail = ((! 0) . extract *** id) . split
-
-
-splitRows :: forall p m n . (KnownNat p, KnownNat m, KnownNat n, p<=m) => L m n -> (L p n, L (m-p) n)
-splitRows (extract -> x) = ( mkL (takeRows p' x) ,
-                             mkL (dropRows p' x) )
-  where
-    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
-
-splitCols :: forall p m n. (KnownNat p, KnownNat m, KnownNat n, KnownNat (n-p), p<=n) => L m n -> (L m p, L m (n-p))
-splitCols = (tr *** tr) . splitRows . tr
-
-
-toRows :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R n]
-toRows (LA.toRows . extract -> vs) = map mkR vs
-
-withRows
-    :: forall n z . KnownNat n
-    => [R n]
-    -> (forall m . KnownNat m => L m n -> z)
-    -> z
-withRows (LA.fromRows . map extract -> m) f =
-    case someNatVal $ fromIntegral $ LA.rows m of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy m)) -> f (mkL m :: L m n)
-
-toColumns :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R m]
-toColumns (LA.toColumns . extract -> vs) = map mkR vs
-
-withColumns
-    :: forall m z . KnownNat m
-    => [R m]
-    -> (forall n . KnownNat n => L m n -> z)
-    -> z
-withColumns (LA.fromColumns . map extract -> m) f =
-    case someNatVal $ fromIntegral $ LA.cols m of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy n)) -> f (mkL m :: L m n)
-
-
-
---------------------------------------------------------------------------------
-
-build
-  :: forall m n . (KnownNat n, KnownNat m)
-    => (ℝ -> ℝ -> ℝ)
-    -> L m n
-build f = r
-  where
-    r = mkL $ LA.build (size r) f
-
---------------------------------------------------------------------------------
-
-withVector
-    :: forall z
-     . Vector ℝ
-    -> (forall n . (KnownNat n) => R n -> z)
-    -> z
-withVector v f =
-    case someNatVal $ fromIntegral $ LA.size v of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy m)) -> f (mkR v :: R m)
-
--- | Useful for constraining two dependently typed vectors to match each
--- other in length when they are unknown at compile-time.
-exactLength
-    :: forall n m . (KnownNat n, KnownNat m)
-    => R m
-    -> Maybe (R n)
-exactLength v = do
-    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy m)
-    return $ mkR (unwrap v)
-
-withMatrix
-    :: forall z
-     . Matrix ℝ
-    -> (forall m n . (KnownNat m, KnownNat n) => L m n -> z)
-    -> z
-withMatrix a f =
-    case someNatVal $ fromIntegral $ rows a of
-       Nothing -> error "static/dynamic mismatch"
-       Just (SomeNat (_ :: Proxy m)) ->
-           case someNatVal $ fromIntegral $ cols a of
-               Nothing -> error "static/dynamic mismatch"
-               Just (SomeNat (_ :: Proxy n)) ->
-                  f (mkL a :: L m n)
-
--- | Useful for constraining two dependently typed matrices to match each
--- other in dimensions when they are unknown at compile-time.
-exactDims
-    :: forall n m j k . (KnownNat n, KnownNat m, KnownNat j, KnownNat k)
-    => L m n
-    -> Maybe (L j k)
-exactDims m = do
-    Refl <- sameNat (Proxy :: Proxy m) (Proxy :: Proxy j)
-    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy k)
-    return $ mkL (unwrap m)
 
 randomVector
     :: forall n . KnownNat n
@@ -554,313 +416,51 @@ uniformSample s (extract -> mins) (extract -> maxs) =
     mkL $ LA.uniformSample s (fromInteger (natVal (Proxy :: Proxy m)))
                            (zip (LA.toList mins) (LA.toList maxs))
 
-meanCov
-    :: forall m n . (KnownNat m, KnownNat n, 1 <= m)
-    => L m n
-    -> (R n, Sym n)
-meanCov (extract -> vs) = mkR *** (Sym . mkL . LA.unSym) $ LA.meanCov vs
-
 --------------------------------------------------------------------------------
 
-class Domain field vec mat | mat -> vec field, vec -> mat field, field -> mat vec
+class Eigen m l v | m -> l, m -> v
   where
-    mul :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => mat m k -> mat k n -> mat m n
-    app :: forall m n . (KnownNat m, KnownNat n) => mat m n -> vec n -> vec m
-    dot :: forall n . (KnownNat n) => vec n -> vec n -> field
-    cross :: vec 3 -> vec 3 -> vec 3
-    diagR ::  forall m n k . (KnownNat m, KnownNat n, KnownNat k) => field -> vec k -> mat m n
-    dvmap :: forall n. KnownNat n => (field -> field) -> vec n -> vec n
-    dmmap :: forall n m. (KnownNat m, KnownNat n) => (field -> field) -> mat n m -> mat n m
-    outer :: forall n m. (KnownNat m, KnownNat n) => vec n -> vec m -> mat n m
-    zipWithVector :: forall n. KnownNat n => (field -> field -> field) -> vec n -> vec n -> vec n
-    det :: forall n. KnownNat n => mat n n -> field
-    invlndet :: forall n. KnownNat n => mat n n -> (mat n n, (field, field))
-    expm :: forall n. KnownNat n => mat n n -> mat n n
-    sqrtm :: forall n. KnownNat n => mat n n -> mat n n
-    inv :: forall n. KnownNat n => mat n n -> mat n n
+    eigensystem :: m -> (l,v)
+    eigenvalues :: m -> l
 
-
-instance Domain ℝ R L
+instance KnownNat n => Eigen (Sym n) (R n) (L n n)
   where
-    mul = mulR
-    app = appR
-    dot = dotR
-    cross = crossR
-    diagR = diagRectR
-    dvmap = mapR
-    dmmap = mapL
-    outer = outerR
-    zipWithVector = zipWithR
-    det = detL
-    invlndet = invlndetL
-    expm = expmL
-    sqrtm = sqrtmL
-    inv = invL
-
-instance Domain ℂ C M
-  where
-    mul = mulC
-    app = appC
-    dot = dotC
-    cross = crossC
-    diagR = diagRectC
-    dvmap = mapC
-    dmmap = mapM'
-    outer = outerC
-    zipWithVector = zipWithC
-    det = detM
-    invlndet = invlndetM
-    expm = expmM
-    sqrtm = sqrtmM
-    inv = invM
-
---------------------------------------------------------------------------------
-
-mulR :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => L m k -> L k n -> L m n
-
-mulR (isKonst -> Just (a,(_,k))) (isKonst -> Just (b,_)) = konst (a * b * fromIntegral k)
-
-mulR (isDiag -> Just (0,a,_)) (isDiag -> Just (0,b,_)) = diagR 0 (mkR v :: R k)
-  where
-    v = a' * b'
-    n = min (LA.size a) (LA.size b)
-    a' = subVector 0 n a
-    b' = subVector 0 n b
-
--- mulR (isDiag -> Just (0,a,_)) (extract -> b) = mkL (asColumn a * takeRows (LA.size a) b)
-
--- mulR (extract -> a) (isDiag -> Just (0,b,_)) = mkL (takeColumns (LA.size b) a * asRow b)
-
-mulR a b = mkL (extract a LA.<> extract b)
-
-
-appR :: (KnownNat m, KnownNat n) => L m n -> R n -> R m
-appR (isDiag -> Just (0, w, _)) v = mkR (w * subVector 0 (LA.size w) (extract v))
-appR m v = mkR (extract m LA.#> extract v)
-
-
-dotR :: KnownNat n => R n -> R n -> ℝ
-dotR (extract -> u) (extract -> v) = LA.dot u v
-
-
-crossR :: R 3 -> R 3 -> R 3
-crossR (extract -> x) (extract -> y) = vec3 z1 z2 z3
-  where
-    z1 = x!1*y!2-x!2*y!1
-    z2 = x!2*y!0-x!0*y!2
-    z3 = x!0*y!1-x!1*y!0
-
-outerR :: (KnownNat m, KnownNat n) => R n -> R m -> L n m
-outerR (extract -> x) (extract -> y) = mkL (LA.outer x y)
-
-mapR :: KnownNat n => (ℝ -> ℝ) -> R n -> R n
-mapR f (unwrap -> v) = mkR (LA.cmap f v)
-
-zipWithR :: KnownNat n => (ℝ -> ℝ -> ℝ) -> R n -> R n -> R n
-zipWithR f (extract -> x) (extract -> y) = mkR (LA.zipVectorWith f x y)
-
-mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
-mapL f = overMatL' (LA.cmap f)
-
-detL :: KnownNat n => Sq n -> ℝ
-detL = LA.det . unwrap
-
-invlndetL :: KnownNat n => Sq n -> (L n n, (ℝ, ℝ))
-invlndetL = BF.first mkL . LA.invlndet . unwrap
-
-expmL :: KnownNat n => Sq n -> Sq n
-expmL = overMatL' LA.expm
-
-sqrtmL :: KnownNat n => Sq n -> Sq n
-sqrtmL = overMatL' LA.sqrtm
-
-invL :: KnownNat n => Sq n -> Sq n
-invL = overMatL' LA.inv
-
---------------------------------------------------------------------------------
-
-mulC :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => M m k -> M k n -> M m n
-
-mulC (isKonstC -> Just (a,(_,k))) (isKonstC -> Just (b,_)) = konst (a * b * fromIntegral k)
-
-mulC (isDiagC -> Just (0,a,_)) (isDiagC -> Just (0,b,_)) = diagR 0 (mkC v :: C k)
-  where
-    v = a' * b'
-    n = min (LA.size a) (LA.size b)
-    a' = subVector 0 n a
-    b' = subVector 0 n b
-
--- mulC (isDiagC -> Just (0,a,_)) (extract -> b) = mkM (asColumn a * takeRows (LA.size a) b)
-
--- mulC (extract -> a) (isDiagC -> Just (0,b,_)) = mkM (takeColumns (LA.size b) a * asRow b)
-
-mulC a b = mkM (extract a LA.<> extract b)
-
-
-appC :: (KnownNat m, KnownNat n) => M m n -> C n -> C m
-appC (isDiagC -> Just (0, w, _)) v = mkC (w * subVector 0 (LA.size w) (extract v))
-appC m v = mkC (extract m LA.#> extract v)
-
-
-dotC :: KnownNat n => C n -> C n -> ℂ
-dotC (extract -> u) (extract -> v) = LA.dot u v
-
-
-crossC :: C 3 -> C 3 -> C 3
-crossC (extract -> x) (extract -> y) = mkC (LA.fromList [z1, z2, z3])
-  where
-    z1 = x!1*y!2-x!2*y!1
-    z2 = x!2*y!0-x!0*y!2
-    z3 = x!0*y!1-x!1*y!0
-
-outerC :: (KnownNat m, KnownNat n) => C n -> C m -> M n m
-outerC (extract -> x) (extract -> y) = mkM (LA.outer x y)
-
-mapC :: KnownNat n => (ℂ -> ℂ) -> C n -> C n
-mapC f (unwrap -> v) = mkC (LA.cmap f v)
-
-zipWithC :: KnownNat n => (ℂ -> ℂ -> ℂ) -> C n -> C n -> C n
-zipWithC f (extract -> x) (extract -> y) = mkC (LA.zipVectorWith f x y)
-
-mapM' :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
-mapM' f = overMatM' (LA.cmap f)
-
-detM :: KnownNat n => M n n -> ℂ
-detM = LA.det . unwrap
-
-invlndetM :: KnownNat n => M n n -> (M n n, (ℂ, ℂ))
-invlndetM = BF.first mkM . LA.invlndet . unwrap
-
-expmM :: KnownNat n => M n n -> M n n
-expmM = overMatM' LA.expm
-
-sqrtmM :: KnownNat n => M n n -> M n n
-sqrtmM = overMatM' LA.sqrtm
-
-invM :: KnownNat n => M n n -> M n n
-invM = overMatM' LA.inv
-
---------------------------------------------------------------------------------
-
-diagRectR :: forall m n k . (KnownNat m, KnownNat n, KnownNat k) => ℝ -> R k -> L m n
-diagRectR x v
-    | m' == 1 = mkL (LA.diagRect x ev m' n')
-    | m'*n' > 0 = r
-    | otherwise = matrix []
-  where
-    r = mkL (asRow (vjoin [scalar x, ev, zeros]))
-    ev = extract v
-    zeros = LA.konst x (max 0 ((min m' n') - LA.size ev))
-    (m',n') = size r
-
-
-diagRectC :: forall m n k . (KnownNat m, KnownNat n, KnownNat k) => ℂ -> C k -> M m n
-diagRectC x v
-    | m' == 1 = mkM (LA.diagRect x ev m' n')
-    | m'*n' > 0 = r
-    | otherwise = fromList []
-  where
-    r = mkM (asRow (vjoin [scalar x, ev, zeros]))
-    ev = extract v
-    zeros = LA.konst x (max 0 ((min m' n') - LA.size ev))
-    (m',n') = size r
-
---------------------------------------------------------------------------------
-
-mean :: (KnownNat n, 1<=n) => R n -> ℝ
-mean v = v <·> (1/dim)
-
-test :: (Bool, IO ())
-test = (ok,info)
-  where
-    ok =   extract (eye :: Sq 5) == ident 5
-           && (unwrap .unSym) (mTm sm :: Sym 3) == tr ((3><3)[1..]) LA.<> (3><3)[1..]
-           && unwrap (tm :: L 3 5) == LA.matrix 5 [1..15]
-           && thingS == thingD
-           && precS == precD
-           && withVector (LA.vector [1..15]) sumV == sumElements (LA.fromList [1..15])
-
-    info = do
-        print $ u
-        print $ v
-        print (eye :: Sq 3)
-        print $ ((u & 5) + 1) <·> v
-        print (tm :: L 2 5)
-        print (tm <> sm :: L 2 3)
-        print thingS
-        print thingD
-        print precS
-        print precD
-        print $ withVector (LA.vector [1..15]) sumV
-        splittest
-
-    sumV w = w <·> konst 1
-
-    u = vec2 3 5
-
-    𝕧 x = vector [x] :: R 1
-
-    v = 𝕧 2 & 4 & 7
-
-    tm :: GL
-    tm = lmat 0 [1..]
-
-    lmat :: forall m n . (KnownNat m, KnownNat n) => ℝ -> [ℝ] -> L m n
-    lmat z xs = r
+    eigenvalues (Sym (extract -> m)) =  mkR . LA.eigenvaluesSH . LA.trustSym $ m
+    eigensystem (Sym (extract -> m)) = (mkR l, mkL v)
       where
-        r = mkL . reshape n' . LA.fromList . take (m'*n') $ xs ++ repeat z
-        (m',n') = size r
+        (l,v) = LA.eigSH . LA.trustSym $ m
 
-    sm :: GSq
-    sm = lmat 0 [1..]
-
-    thingS = (u & 1) <·> tr q #> q #> v
+instance KnownNat n => Eigen (Sq n) (C n) (M n n)
+  where
+    eigenvalues (extract -> m) = mkC . LA.eigenvalues $ m
+    eigensystem (extract -> m) = (mkC l, mkM v)
       where
-        q = tm :: L 10 3
-
-    thingD = vjoin [ud1 u, 1] LA.<.> tr m LA.#> m LA.#> ud1 v
-      where
-        m = LA.matrix 3 [1..30]
-
-    precS = (1::Double) + (2::Double) * ((1 :: R 3) * (u & 6)) <·> konst 2 #> v
-    precD = 1 + 2 * vjoin[ud1 u, 6] LA.<.> LA.konst 2 (LA.size (ud1 u) +1, LA.size (ud1 v)) LA.#> ud1 v
+        (l,v) = LA.eig m
 
 
-splittest
-    = do
-    let v = range :: R 7
-        a = snd (split v) :: R 4
-    print $ a
-    print $ snd . headTail . snd . headTail $ v
-    print $ first (vec3 1 2 3)
-    print $ second (vec3 1 2 3)
-    print $ third (vec3 1 2 3)
-    print $ (snd $ splitRows eye :: L 4 6)
- where
-    first v = fst . headTail $ v
-    second v = first . snd . headTail $ v
-    third v = first . snd . headTail . snd . headTail $ v
 
 
-instance (KnownNat n', KnownNat m') => Testable (L n' m')
+sym :: KnownNat n => Sq n -> Sym n
+sym m = Sym $ (m + tr m)/2
+
+mTm :: (KnownNat m, KnownNat n) => L m n -> Sym n
+mTm x = Sym (tr x <> x)
+
+unSym :: Sym n -> Sq n
+unSym (Sym x) = x
+
+
+
+newtype Sym n = Sym (Sq n) deriving Show
+
+instance (KnownNat n) => Disp (Sym n)
   where
-    checkT _ = test
+    disp n (Sym x) = do
+        let a = extract x
+        let su = LA.dispf n a
+        printf "Sym %d" (cols a) >> putStr (dropWhile (/='\n') $ su)
 
---------------------------------------------------------------------------------
 
-instance KnownNat n => Normed (R n)
-  where
-    norm_0 v = norm_0 (extract v)
-    norm_1 v = norm_1 (extract v)
-    norm_2 v = norm_2 (extract v)
-    norm_Inf v = norm_Inf (extract v)
-
-instance (KnownNat m, KnownNat n) => Normed (L m n)
-  where
-    norm_0 m = norm_0 (extract m)
-    norm_1 m = norm_1 (extract m)
-    norm_2 m = norm_2 (extract m)
-    norm_Inf m = norm_Inf (extract m)
 
 mkSym f = Sym . f . unSym
 mkSym2 f x y = Sym (f (unSym x) (unSym y))
@@ -907,6 +507,143 @@ instance KnownNat n => Transposable (Sym n) (Sym n) where
     tr  = id
     tr' = id
 
+
+chol :: KnownNat n => Sym n -> Sq n
+chol (extract . unSym -> m) = mkL $ LA.chol $ LA.trustSym m
+
+--------------------------------------------------------------------------------
+
+withNullspace
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k . (KnownNat k) => L n k -> z)
+    -> z
+withNullspace (LA.nullspace . extract -> a) f =
+    case someNatVal $ fromIntegral $ cols a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
+
+withOrth
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k. (KnownNat k) => L n k -> z)
+    -> z
+withOrth (LA.orth . extract -> a) f =
+    case someNatVal $ fromIntegral $ cols a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
+
+withCompactSVD
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k . (KnownNat k) => (L m k, R k, L n k) -> z)
+    -> z
+withCompactSVD (LA.compactSVD . extract -> (u,s,v)) f =
+    case someNatVal $ fromIntegral $ LA.size s of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL u :: L m k, mkR s :: R k, mkL v :: L n k)
+
+--------------------------------------------------------------------------------
+
+qr :: (KnownNat m, KnownNat n) => L m n -> (L m m, L m n)
+qr (extract -> x) = (mkL q, mkL r)
+  where
+    (q,r) = LA.qr x
+
+
+--------------------------------------------------------------------------------
+
+𝑖 :: Sized ℂ s c => s
+𝑖 = konst iC
+
+newtype Her n = Her (M n n)
+
+
+her :: KnownNat n => M n n -> Her n
+her m = Her $ (m + LA.tr m)/2
+
 instance KnownNat n => Transposable (Her n) (Her n) where
     tr          = id
     tr' (Her m) = Her (tr' m)
+
+instance (KnownNat n) => Disp (Her n)
+  where
+    disp n (Her x) = do
+        let a = extract x
+        let su = LA.dispcf n a
+        printf "Her %d" (cols a) >> putStr (dropWhile (/='\n') $ su)
+
+--------------------------------------------------------------------------------
+-- type GL = forall n m . (KnownNat n, KnownNat m) => L m n
+-- type GSq = forall n . KnownNat n => Sq n
+
+-- test :: (Bool, IO ())
+-- test = (ok,info)
+--   where
+--     ok =   extract (eye :: Sq 5) == ident 5
+--            && (unwrap .unSym) (mTm sm :: Sym 3) == tr ((3><3)[1..]) LA.<> (3><3)[1..]
+--            && unwrap (tm :: L 3 5) == LA.matrix 5 [1..15]
+--            && thingS == thingD
+--            && precS == precD
+--            && withVector (LA.vector [1..15]) sumV == sumElements (LA.fromList [1..15])
+
+--     info = do
+--         print $ u
+--         print $ v
+--         print (eye :: Sq 3)
+--         print $ ((u & 5) + 1) <·> v
+--         print (tm :: L 2 5)
+--         print (tm <> sm :: L 2 3)
+--         print thingS
+--         print thingD
+--         print precS
+--         print precD
+--         print $ withVector (LA.vector [1..15]) sumV
+--         splittest
+
+--     sumV w = w <·> konst 1
+
+--     u = vec2 3 5
+
+--     𝕧 x = vector [x] :: R 1
+
+--     v = 𝕧 2 & 4 & 7
+
+--     tm :: GL
+--     tm = lmat 0 [1..]
+
+--     lmat :: forall m n . (KnownNat m, KnownNat n) => ℝ -> [ℝ] -> L m n
+--     lmat z xs = r
+--       where
+--         r = mkL . reshape n' . LA.fromList . take (m'*n') $ xs ++ repeat z
+--         (m',n') = size r
+
+--     sm :: GSq
+--     sm = lmat 0 [1..]
+
+--     thingS = (u & 1) <·> tr q #> q #> v
+--       where
+--         q = tm :: L 10 3
+
+--     thingD = vjoin [ud1 u, 1] LA.<.> tr m LA.#> m LA.#> ud1 v
+--       where
+--         m = LA.matrix 3 [1..30]
+
+--     precS = (1::Double) + (2::Double) * ((1 :: R 3) * (u & 6)) <·> konst 2 #> v
+--     precD = 1 + 2 * vjoin[ud1 u, 6] LA.<.> LA.konst 2 (LA.size (ud1 u) +1, LA.size (ud1 v)) LA.#> ud1 v
+
+
+-- splittest
+--     = do
+--     let v = range :: R 7
+--         a = snd (split v) :: R 4
+--     print $ a
+--     print $ snd . headTail . snd . headTail $ v
+--     print $ first (vec3 1 2 3)
+--     print $ second (vec3 1 2 3)
+--     print $ third (vec3 1 2 3)
+--     print $ (snd $ splitRows eye :: L 4 6)
+--  where
+--     first v = fst . headTail $ v
+--     second v = first . snd . headTail $ v
+--     third v = first . snd . headTail . snd . headTail $ v

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -70,14 +70,13 @@ import Numeric.LinearAlgebra hiding (
     toComplex, fromComplex, complex, real, magnitude, diag
     )
 import qualified Numeric.LinearAlgebra as LA
-import qualified Numeric.LinearAlgebra.Static.Real as R
-import qualified Numeric.LinearAlgebra.Static.Complex as C
+import qualified Internal.Static.Real as R
+import qualified Internal.Static.Complex as C
 import Data.Proxy(Proxy(..))
 import Internal.Static
 import Text.Printf
 #if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
--- import Data.Finite (Finite)
 #endif
 
 

--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -438,6 +438,37 @@ instance KnownNat n => Eigen (Sq n) (C n) (M n n)
         (l,v) = LA.eig m
 
 
+--------------------------------------------------------------------------------
+
+instance KnownNat n => Normed (R n)
+  where
+    norm_0 v = norm_0 (extract v)
+    norm_1 v = norm_1 (extract v)
+    norm_2 v = norm_2 (extract v)
+    norm_Inf v = norm_Inf (extract v)
+
+instance KnownNat n => Normed (C n)
+  where
+    norm_0 v = norm_0 (extract v)
+    norm_1 v = norm_1 (extract v)
+    norm_2 v = norm_2 (extract v)
+    norm_Inf v = norm_Inf (extract v)
+
+instance (KnownNat m, KnownNat n) => Normed (L m n)
+  where
+    norm_0 m = norm_0 (extract m)
+    norm_1 m = norm_1 (extract m)
+    norm_2 m = norm_2 (extract m)
+    norm_Inf m = norm_Inf (extract m)
+
+instance (KnownNat m, KnownNat n) => Normed (M m n)
+  where
+    norm_0 m = norm_0 (extract m)
+    norm_1 m = norm_1 (extract m)
+    norm_2 m = norm_2 (extract m)
+    norm_Inf m = norm_Inf (extract m)
+
+--------------------------------------------------------------------------------
 
 
 sym :: KnownNat n => Sq n -> Sym n

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
@@ -1,0 +1,474 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoStarIsType #-}
+
+
+{- |
+Module      :  Numeric.LinearAlgebra.Static
+Copyright   :  (c) Alberto Ruiz 2014
+License     :  BSD3
+Stability   :  experimental
+
+Experimental interface with statically checked dimensions.
+
+See code examples at http://dis.um.es/~alberto/hmatrix/static.html.
+
+-}
+
+module Numeric.LinearAlgebra.Static.Complex(
+    -- * Vector
+       ℝ, R,
+    vec2, vec3, vec4, (&), (#), split, headTail,
+    vector,
+    linspace, range, dim,
+    -- * Matrix
+    L, Sq, build,
+    row, col, (|||),(===), splitRows, splitCols,
+    unrow, uncol,
+    tr,
+    eye,
+    diag, diagR,
+    blockAt,
+    matrix,
+    -- * Complex
+    ℂ, C, M,
+    -- * Products
+    (<>),(#>),(<.>),(<·>),
+    mul, app, dot,
+    -- * Linear Systems
+    linSolve, (<\>),
+    -- * Factorizations
+    withCompactSVD,
+    withNullspace, withOrth, qr,
+    -- * Norms
+    Normed(..),
+    -- * Element accessing
+    vAt, mAt,
+    -- * Misc
+    mean,
+    Disp(..),
+    cross, outer, mapC, mapM, det, zipWith,
+    invlndet, expm, sqrtm, inv,
+    isKonst, isKonstV,
+    withVector, withMatrix, exactLength, exactDims,
+    toRows, toColumns, withRows, withColumns,
+    flatten, reshape,
+    Sized(..),
+) where
+
+
+import GHC.TypeLits
+import Numeric.LinearAlgebra hiding (
+    (<>),(#>),(<.>),Konst(..),diag, disp,(===),(|||),
+    row,col,vector,matrix,linspace,toRows,toColumns,
+    (<\>),fromList,takeDiag,svd,eig,eigSH,
+    eigenvalues,eigenvaluesSH,build,
+    qr,size,dot,chol,range,R,C,sym,mTm,unSym,
+    randomVector,rand,randn,gaussianSample,uniformSample,meanCov,
+    toComplex, fromComplex, complex, real, magnitude, diag,
+    cross, outer, det, invlndet, expm, sqrtm, inv,
+    flatten, reshape
+    )
+import qualified Numeric.LinearAlgebra as LA
+import qualified Numeric.LinearAlgebra.Devel as LA
+import Data.Proxy(Proxy(..))
+import Internal.Static
+import Control.Arrow((***), Arrow (first))
+import Data.Type.Equality ((:~:)(Refl))
+import qualified Data.Bifunctor as BF (first)
+
+import Prelude hiding (zipWith, mapM, (<>))
+import Data.Finite (Finite, getFinite)
+
+
+infixl 4 &
+(&) :: forall n . KnownNat n
+    => C n -> ℂ -> C (n+1)
+u & x = u # (konst x :: C 1)
+
+infixl 4 #
+(#) :: forall n m . (KnownNat n, KnownNat m)
+    => C n -> C m -> C (n+m)
+(C u) # (C v) = C (vconcat u v)
+
+
+
+vec2 :: ℂ -> ℂ -> C 2
+vec2 a b = C (gvec2 a b)
+
+vec3 :: ℂ -> ℂ -> ℂ -> C 3
+vec3 a b c = C (gvec3 a b c)
+
+
+vec4 :: ℂ -> ℂ -> ℂ -> ℂ -> C 4
+vec4 a b c d = C (gvec4 a b c d)
+
+vector :: KnownNat n => [ℂ] -> C n
+vector = fromList
+
+matrix :: (KnownNat m, KnownNat n) => [ℂ] -> M m n
+matrix = fromList
+
+linspace :: forall n . KnownNat n => (ℂ,ℂ) -> C n
+linspace (a,b) = v
+  where
+    v = mkC (LA.linspace (size v) (a,b))
+
+range :: forall n . KnownNat n => C n
+range = v
+  where
+    v = mkC (LA.linspace d (1,fromIntegral d))
+    d = size v
+
+dim :: forall n . KnownNat n => C n
+dim = v
+  where
+    v = mkC (scalar (fromIntegral $ size v))
+
+
+--------------------------------------------------------------------------------
+
+diag :: KnownNat n => C n -> Sq n
+diag = diagR 0
+
+eye :: KnownNat n => Sq n
+eye = diag 1
+
+
+blockAt :: forall m n . (KnownNat m, KnownNat n) =>  ℂ -> Int -> Int -> Matrix ℂ -> M m n
+blockAt x r c a = res
+  where
+    z = scalar x
+    z1 = LA.konst x (r,c)
+    z2 = LA.konst x (max 0 (m'-(ra+r)), max 0 (n'-(ca+c)))
+    ra = min (rows a) . max 0 $ m'-r
+    ca = min (cols a) . max 0 $ n'-c
+    sa = subMatrix (0,0) (ra, ca) a
+    (m',n') = size res
+    res = mkM $ fromBlocks [[z1,z,z],[z,sa,z],[z,z,z2]]
+
+--------------------------------------------------------------------------------
+
+
+row :: KnownNat n => C n -> M 1 n
+row = mkM . asRow . extract
+
+col :: KnownNat n => C n -> M n 1
+col = tr . row
+
+unrow :: KnownNat n => M 1 n -> C n
+unrow = mkC . head . LA.toRows . extract
+
+uncol :: KnownNat n => M n 1 -> C n
+uncol = unrow . tr
+
+
+infixl 2 ===
+(===) :: (KnownNat r1, KnownNat r2, KnownNat c) => M r1 c -> M r2 c -> M (r1+r2) c
+a === b = mkM (extract a LA.=== extract b)
+
+
+infixl 3 |||
+(|||) :: (KnownNat r, KnownNat c1, KnownNat c2, KnownNat (c1+c2)) => M r c1 -> M r c2 -> M r (c1+c2)
+a ||| b = tr (tr a === tr b)
+
+
+type Sq n  = M n n
+--type CSq n = CL n n
+
+
+isKonst :: forall m n . (KnownNat m, KnownNat n) => M m n -> Maybe (ℂ,(Int,Int))
+isKonst s@(unwrap -> x)
+    | singleM x = Just (x `atIndex` (0,0), size s)
+    | otherwise = Nothing
+
+isKonstV :: forall n . KnownNat n => C n -> Maybe (ℂ,Int)
+isKonstV s@(unwrap -> x)
+    | singleV x = Just (x `atIndex` 0, size s)
+    | otherwise = Nothing
+
+infixr 8 <>
+(<>) :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => M m k -> M k n -> M m n
+(<>) = mul
+
+
+infixr 8 #>
+(#>) :: (KnownNat m, KnownNat n) => M m n -> C n -> C m
+(#>) = app
+
+
+infixr 8 <·>
+(<·>) :: KnownNat n => C n -> C n -> ℂ
+(<·>) = dot
+
+infixr 8 <.>
+(<.>) :: KnownNat n => C n -> C n -> ℂ
+(<.>) = dot
+
+
+linSolve :: (KnownNat m, KnownNat n) => M m m -> M m n -> Maybe (M m n)
+linSolve (extract -> a) (extract -> b) = fmap mkM (LA.linearSolve a b)
+
+(<\>) :: (KnownNat m, KnownNat n, KnownNat r) => M m n -> M m r -> M n r
+(extract -> a) <\> (extract -> b) = mkM (a LA.<\> b)
+
+
+--------------------------------------------------------------------------------
+
+withNullspace
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k . (KnownNat k) => L n k -> z)
+    -> z
+withNullspace (LA.nullspace . extract -> a) f =
+    case someNatVal $ fromIntegral $ cols a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
+
+withOrth
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k. (KnownNat k) => L n k -> z)
+    -> z
+withOrth (LA.orth . extract -> a) f =
+    case someNatVal $ fromIntegral $ cols a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL a :: L n k)
+
+withCompactSVD
+    :: forall m n z . (KnownNat m, KnownNat n)
+    => L m n
+    -> (forall k . (KnownNat k) => (L m k, R k, L n k) -> z)
+    -> z
+withCompactSVD (LA.compactSVD . extract -> (u,s,v)) f =
+    case someNatVal $ fromIntegral $ LA.size s of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy k)) -> f (mkL u :: L m k, mkR s :: R k, mkL v :: L n k)
+
+--------------------------------------------------------------------------------
+
+qr :: (KnownNat m, KnownNat n) => L m n -> (L m m, L m n)
+qr (extract -> x) = (mkL q, mkL r)
+  where
+    (q,r) = LA.qr x
+
+
+split :: forall p n . (KnownNat p, KnownNat n, p<=n) => C n -> (C p, C (n-p))
+split (extract -> v) = ( mkC (subVector 0 p' v) ,
+                          mkC (subVector p' (LA.size v - p') v) )
+  where
+    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
+
+
+headTail :: (KnownNat n, 1<=n) => C n -> (ℂ, C (n-1))
+headTail = first ((! 0) . extract) . split
+
+
+splitRows :: forall p m n . (KnownNat p, KnownNat m, KnownNat n, p<=m) => M m n -> (M p n, M (m-p) n)
+splitRows (extract -> x) = ( mkM (takeRows p' x) ,
+                              mkM (dropRows p' x) )
+  where
+    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
+
+splitCols :: forall p m n. (KnownNat p, KnownNat m, KnownNat n, KnownNat (n-p), p<=n) => M m n -> (M m p, M m (n-p))
+splitCols = (tr *** tr) . splitRows . tr
+
+
+toRows :: forall m n . (KnownNat m, KnownNat n) => M m n -> [C n]
+toRows (LA.toRows . extract -> vs) = map mkC vs
+
+withRows
+    :: forall n z . KnownNat n
+    => [C n]
+    -> (forall m . KnownNat m => M m n -> z)
+    -> z
+withRows (LA.fromRows . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.rows m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) -> f (mkM m :: M m n)
+
+toColumns :: forall m n . (KnownNat m, KnownNat n) => M m n -> [C m]
+toColumns (LA.toColumns . extract -> vs) = map mkC vs
+
+withColumns
+    :: forall m z . KnownNat m
+    => [C m]
+    -> (forall n . KnownNat n => M m n -> z)
+    -> z
+withColumns (LA.fromColumns . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.cols m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy n)) -> f (mkM m :: M m n)
+
+
+--------------------------------------------------------------------------------
+
+build
+  :: forall m n . (KnownNat n, KnownNat m)
+    => (ℂ -> ℂ -> ℂ)
+    -> M m n
+build f = r
+  where
+    r = mkM $ LA.build (size r) f
+
+--------------------------------------------------------------------------------
+
+withVector
+    :: forall z
+     . Vector ℂ
+    -> (forall n . (KnownNat n) => C n -> z)
+    -> z
+withVector v f =
+    case someNatVal $ fromIntegral $ LA.size v of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) -> f (mkC v :: C m)
+
+-- | Useful for constraining two dependently typed vectors to match each
+-- other in length when they are unknown at compile-time.
+exactLength
+    :: forall n m . (KnownNat n, KnownNat m)
+    => C m
+    -> Maybe (C n)
+exactLength v = do
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy m)
+    return $ mkC (unwrap v)
+
+withMatrix
+    :: forall z
+     . Matrix ℂ
+    -> (forall m n . (KnownNat m, KnownNat n) => M m n -> z)
+    -> z
+withMatrix a f =
+    case someNatVal $ fromIntegral $ rows a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) ->
+           case someNatVal $ fromIntegral $ cols a of
+               Nothing -> error "static/dynamic mismatch"
+               Just (SomeNat (_ :: Proxy n)) ->
+                  f (mkM a :: M m n)
+
+-- | Useful for constraining two dependently typed matrices to match each
+-- other in dimensions when they are unknown at compile-time.
+exactDims
+    :: forall n m j k . (KnownNat n, KnownNat m, KnownNat j, KnownNat k)
+    => M m n
+    -> Maybe (M j k)
+exactDims m = do
+    Refl <- sameNat (Proxy :: Proxy m) (Proxy :: Proxy j)
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy k)
+    return $ mkM (unwrap m)
+
+
+-- --------------------------------------------------------------------------------
+
+mul :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => M m k -> M k n -> M m n
+
+mul (isKonst -> Just (a,(_,k))) (isKonst -> Just (b,_)) = konst (a * b * fromIntegral k)
+
+mul (isDiagC -> Just (0,a,_)) (isDiagC -> Just (0,b,_)) = diagR 0 (mkC v :: C k)
+  where
+    v = a' * b'
+    n = min (LA.size a) (LA.size b)
+    a' = subVector 0 n a
+    b' = subVector 0 n b
+
+-- mul (isDiagC -> Just (0,a,_)) (extract -> b) = mkM (asColumn a * takeRows (LA.size a) b)
+
+-- mul (extract -> a) (isDiagC -> Just (0,b,_)) = mkM (takeColumns (LA.size b) a * asRow b)
+
+mul a b = mkM (extract a LA.<> extract b)
+
+
+app :: (KnownNat m, KnownNat n) => M m n -> C n -> C m
+app (isDiagC -> Just (0, w, _)) v = mkC (w * subVector 0 (LA.size w) (extract v))
+app m v = mkC (extract m LA.#> extract v)
+
+
+dot :: KnownNat n => C n -> C n -> ℂ
+dot (extract -> u) (extract -> v) = LA.dot u v
+
+
+cross :: C 3 -> C 3 -> C 3
+cross (extract -> x) (extract -> y) = mkC (LA.fromList [z1, z2, z3])
+  where
+    z1 = x!1*y!2-x!2*y!1
+    z2 = x!2*y!0-x!0*y!2
+    z3 = x!0*y!1-x!1*y!0
+
+outer :: (KnownNat m, KnownNat n) => C n -> C m -> M n m
+outer (extract -> x) (extract -> y) = mkM (LA.outer x y)
+
+mapC :: KnownNat n => (ℂ -> ℂ) -> C n -> C n
+mapC f (unwrap -> v) = mkC (LA.cmap f v)
+
+zipWith :: KnownNat n => (ℂ -> ℂ -> ℂ) -> C n -> C n -> C n
+zipWith f (extract -> x) (extract -> y) = mkC (LA.zipVectorWith f x y)
+
+mapM :: (KnownNat n, KnownNat m) => (ℂ -> ℂ) -> M n m -> M n m
+mapM f = overMatM' (LA.cmap f)
+
+det :: KnownNat n => M n n -> ℂ
+det = LA.det . unwrap
+
+invlndet :: KnownNat n => M n n -> (M n n, (ℂ, ℂ))
+invlndet = BF.first mkM . LA.invlndet . unwrap
+
+expm :: KnownNat n => M n n -> M n n
+expm = overMatM' LA.expm
+
+sqrtm :: KnownNat n => M n n -> M n n
+sqrtm = overMatM' LA.sqrtm
+
+inv :: KnownNat n => M n n -> M n n
+inv = overMatM' LA.inv
+
+
+flatten
+  :: forall m n. (KnownNat m, KnownNat n, KnownNat (m * n)) => M m n -> C (m * n)
+flatten (extract -> mat') = vector (LA.toList (LA.flatten mat'))
+
+reshape :: forall m n k. (KnownNat m, KnownNat n, KnownNat k, n ~ (k * m)) => C n -> M k m
+reshape (extract -> v) = mkM $ LA.reshape nrow v
+  where
+    nrow = (fromIntegral . natVal) (undefined :: Proxy k)
+
+
+diagR :: forall m n k . (KnownNat m, KnownNat n, KnownNat k) => ℂ -> C k -> M m n
+diagR x v
+    | m' == 1 = mkM (LA.diagRect x ev m' n')
+    | m'*n' > 0 = r
+    | otherwise = fromList []
+  where
+    r = mkM (asRow (vjoin [scalar x, ev, zeros]))
+    ev = extract v
+    zeros = LA.konst x (max 0 ((min m' n') - LA.size ev))
+    (m',n') = size r
+
+
+mean :: (KnownNat n, 1<=n) => C n -> ℂ
+mean v = v <·> (1/dim)
+
+
+--------------------------------------------------------------------------------
+-- Element access using the Finite type
+
+vAt :: KnownNat n => C n -> Finite n -> ℂ
+vAt v i = extract v LA.! fromIntegral (getFinite i)
+
+mAt :: (KnownNat m, KnownNat n) => M m n -> Finite m -> Finite n -> ℂ
+mAt m i' j' = extract m `LA.atIndex` (i, j)
+  where i = fromIntegral (getFinite i')
+        j = fromIntegral (getFinite j')

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
@@ -53,8 +53,6 @@ module Numeric.LinearAlgebra.Static.Complex(
     -- * Factorizations
     withCompactSVD,
     withNullspace, withOrth, qr,
-    -- * Norms
-    Normed(..),
     -- * Element accessing
     vAt, mAt,
     -- * Misc

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Complex.hs
@@ -53,8 +53,6 @@ module Numeric.LinearAlgebra.Static.Complex(
     -- * Factorizations
     withCompactSVD,
     withNullspace, withOrth, qr,
-    -- * Element accessing
-    vAt, mAt,
     -- * Misc
     mean,
     Disp(..),
@@ -89,7 +87,6 @@ import Data.Type.Equality ((:~:)(Refl))
 import qualified Data.Bifunctor as BF (first)
 
 import Prelude hiding (zipWith, mapM, (<>))
-import Data.Finite (Finite, getFinite)
 
 
 infixl 4 &
@@ -452,21 +449,9 @@ diagR x v
   where
     r = mkM (asRow (vjoin [scalar x, ev, zeros]))
     ev = extract v
-    zeros = LA.konst x (max 0 ((min m' n') - LA.size ev))
+    zeros = LA.konst x (max 0 (min m' n' - LA.size ev))
     (m',n') = size r
 
 
 mean :: (KnownNat n, 1<=n) => C n -> ℂ
 mean v = v <·> (1/dim)
-
-
---------------------------------------------------------------------------------
--- Element access using the Finite type
-
-vAt :: KnownNat n => C n -> Finite n -> ℂ
-vAt v i = extract v LA.! fromIntegral (getFinite i)
-
-mAt :: (KnownNat m, KnownNat n) => M m n -> Finite m -> Finite n -> ℂ
-mAt m i' j' = extract m `LA.atIndex` (i, j)
-  where i = fromIntegral (getFinite i')
-        j = fromIntegral (getFinite j')

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
@@ -48,8 +48,6 @@ module Numeric.LinearAlgebra.Static.Real(
     (<>),(#>),(<.>),(<·>),
     -- * Linear Systems
     linSolve, (<\>),
-    -- * Norms
-    Normed(..),
     -- * Random arrays
     Seed, RandDist(..),
     -- * Element accessing

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
@@ -51,7 +51,7 @@ module Numeric.LinearAlgebra.Static.Real(
     -- * Random arrays
     Seed, RandDist(..),
     -- * Element accessing
-    vAt, mAt,
+    -- vAt, mAt,
     -- * Misc
     mean,
     Disp(..),
@@ -82,12 +82,10 @@ import qualified Numeric.LinearAlgebra as LA
 import qualified Numeric.LinearAlgebra.Devel as LA
 import Data.Proxy(Proxy(..))
 import Internal.Static
-import Control.Arrow((***))
+import Control.Arrow(first, (***))
 import Data.Type.Equality ((:~:)(Refl))
 import qualified Data.Bifunctor as BF (first)
-
 import Prelude hiding (zipWith, (<>))
-import Data.Finite (Finite, getFinite)
 
 
 ud1 :: R n -> Vector ℝ
@@ -289,7 +287,7 @@ split (extract -> v) = ( mkR (subVector 0 p' v) ,
 
 
 headTail :: (KnownNat n, 1<=n) => R n -> (ℝ, R (n-1))
-headTail = ((! 0) . extract *** id) . split
+headTail = first ((LA.! 0) . extract) . split
 
 
 splitRows :: forall p m n . (KnownNat p, KnownNat m, KnownNat n, p<=m) => L m n -> (L p n, L (m-p) n)
@@ -415,9 +413,9 @@ dot (extract -> u) (extract -> v) = LA.dot u v
 cross :: R 3 -> R 3 -> R 3
 cross (extract -> x) (extract -> y) = vec3 z1 z2 z3
   where
-    z1 = x!1*y!2-x!2*y!1
-    z2 = x!2*y!0-x!0*y!2
-    z3 = x!0*y!1-x!1*y!0
+    z1 = x LA.! 1 * y LA.! 2 - x LA.! 2 * y LA.! 1
+    z2 = x LA.! 2 * y LA.! 0 - x LA.! 0 * y LA.! 2
+    z3 = x LA.! 0 * y LA.! 1 - x LA.! 1 * y LA.! 0
 
 outer :: (KnownNat m, KnownNat n) => R n -> R m -> L n m
 outer (extract -> x) (extract -> y) = mkL (LA.outer x y)
@@ -472,13 +470,19 @@ mean :: (KnownNat n, 1<=n) => R n -> ℝ
 mean v = v <·> (1/dim)
 
 
---------------------------------------------------------------------------------
--- Element access using the Finite type
 
-vAt :: KnownNat n => R n -> Finite n -> ℝ
-vAt v i = extract v LA.! fromIntegral (getFinite i)
+-- instance KnownNat n => At (R n) Double where
+--   type IndexAt (R n) = Finite n
+--   v ! i =  extract v LA.! fromIntegral (getFinite i)
 
-mAt :: (KnownNat m, KnownNat n) => L m n -> Finite m -> Finite n -> ℝ
-mAt m i' j' = extract m `LA.atIndex` (i, j)
-  where i = fromIntegral (getFinite i')
-        j = fromIntegral (getFinite j')
+-- instance (KnownNat m, KnownNat n) => At (L m n) Double where
+--   type IndexAt (R n) = (Finite n, Finite n)
+--   v ! i =  extract v LA.! fromIntegral (getFinite i)
+
+-- vAt :: KnownNat n => R n -> Finite n -> ℝ
+-- vAt v i = extract v LA.! fromIntegral (getFinite i)
+
+-- mAt :: (KnownNat m, KnownNat n) => L m n -> Finite m -> Finite n -> ℝ
+-- mAt m i' j' = extract m `LA.atIndex` (i, j)
+--   where i = fromIntegral (getFinite i')
+--         j = fromIntegral (getFinite j')

--- a/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static/Real.hs
@@ -1,0 +1,486 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoStarIsType #-}
+
+
+{- |
+Module      :  Numeric.LinearAlgebra.Static
+Copyright   :  (c) Alberto Ruiz 2014
+License     :  BSD3
+Stability   :  experimental
+
+Experimental interface with statically checked dimensions.
+
+See code examples at http://dis.um.es/~alberto/hmatrix/static.html.
+
+-}
+
+module Numeric.LinearAlgebra.Static.Real(
+    -- * Vector
+       ℝ, R,
+    vec2, vec3, vec4, (&), (#), split, headTail,
+    vector,
+    linspace, range, dim,
+    -- * Matrix
+    L, Sq, build,
+    row, col, (|||),(===), splitRows, splitCols,
+    unrow, uncol,
+    tr,
+    eye,
+    diag, diagR,
+    blockAt,
+    matrix,
+    -- * Products
+    mul, app, dot,
+    (<>),(#>),(<.>),(<·>),
+    -- * Linear Systems
+    linSolve, (<\>),
+    -- * Norms
+    Normed(..),
+    -- * Random arrays
+    Seed, RandDist(..),
+    -- * Element accessing
+    vAt, mAt,
+    -- * Misc
+    mean,
+    Disp(..),
+    cross, outer, mapR, mapL, det, zipWith,
+    invlndet, expm, sqrtm, inv,
+    isKonst, isKonstV,
+    withVector, withMatrix, exactLength, exactDims,
+    toRows, toColumns, withRows, withColumns,
+    flatten, reshape,
+    Sized(..), Diag(..),
+
+) where
+
+
+import GHC.TypeLits
+import Numeric.LinearAlgebra hiding (
+    (<>),(#>),(<.>),Konst(..),diag, disp,(===),(|||),
+    row,col,vector,matrix,linspace,toRows,toColumns,
+    (<\>),fromList,takeDiag,svd,eig,eigSH,
+    eigenvalues,eigenvaluesSH,build,
+    qr,size,dot,chol,range,R,C,sym,mTm,unSym,
+    randomVector,rand,randn,gaussianSample,uniformSample,meanCov,
+    toComplex, fromComplex, complex, real, magnitude,
+    cross, outer, det, invlndet, expm, sqrtm, inv,
+    flatten, reshape
+    )
+import qualified Numeric.LinearAlgebra as LA
+import qualified Numeric.LinearAlgebra.Devel as LA
+import Data.Proxy(Proxy(..))
+import Internal.Static
+import Control.Arrow((***))
+import Data.Type.Equality ((:~:)(Refl))
+import qualified Data.Bifunctor as BF (first)
+
+import Prelude hiding (zipWith, (<>))
+import Data.Finite (Finite, getFinite)
+
+
+ud1 :: R n -> Vector ℝ
+ud1 (R (Dim v)) = v
+
+
+infixl 4 &
+(&) :: forall n . KnownNat n
+    => R n -> ℝ -> R (n+1)
+u & x = u # (konst x :: R 1)
+
+infixl 4 #
+(#) :: forall n m . (KnownNat n, KnownNat m)
+    => R n -> R m -> R (n+m)
+(R u) # (R v) = R (vconcat u v)
+
+
+
+vec2 :: ℝ -> ℝ -> R 2
+vec2 a b = R (gvec2 a b)
+
+vec3 :: ℝ -> ℝ -> ℝ -> R 3
+vec3 a b c = R (gvec3 a b c)
+
+
+vec4 :: ℝ -> ℝ -> ℝ -> ℝ -> R 4
+vec4 a b c d = R (gvec4 a b c d)
+
+vector :: KnownNat n => [ℝ] -> R n
+vector = fromList
+
+matrix :: (KnownNat m, KnownNat n) => [ℝ] -> L m n
+matrix = fromList
+
+linspace :: forall n . KnownNat n => (ℝ,ℝ) -> R n
+linspace (a,b) = v
+  where
+    v = mkR (LA.linspace (size v) (a,b))
+
+range :: forall n . KnownNat n => R n
+range = v
+  where
+    v = mkR (LA.linspace d (1,fromIntegral d))
+    d = size v
+
+dim :: forall n . KnownNat n => R n
+dim = v
+  where
+    v = mkR (scalar (fromIntegral $ size v))
+
+--------------------------------------------------------------------------------
+
+
+ud2 :: L m n -> Matrix ℝ
+ud2 (L (Dim (Dim x))) = x
+
+
+--------------------------------------------------------------------------------
+
+diag :: KnownNat n => R n -> Sq n
+diag = diagR 0
+
+eye :: KnownNat n => Sq n
+eye = diag 1
+
+--------------------------------------------------------------------------------
+
+blockAt :: forall m n . (KnownNat m, KnownNat n) =>  ℝ -> Int -> Int -> Matrix Double -> L m n
+blockAt x r c a = res
+  where
+    z = scalar x
+    z1 = LA.konst x (r,c)
+    z2 = LA.konst x (max 0 (m'-(ra+r)), max 0 (n'-(ca+c)))
+    ra = min (rows a) . max 0 $ m'-r
+    ca = min (cols a) . max 0 $ n'-c
+    sa = subMatrix (0,0) (ra, ca) a
+    (m',n') = size res
+    res = mkL $ fromBlocks [[z1,z,z],[z,sa,z],[z,z,z2]]
+
+--------------------------------------------------------------------------------
+
+
+row :: R n -> L 1 n
+row = mkL . asRow . ud1
+
+col :: KnownNat n => R n -> L n 1
+col = tr . row
+
+unrow :: L 1 n -> R n
+unrow = mkR . head . LA.toRows . ud2
+
+uncol :: KnownNat n => L n 1 -> R n
+uncol = unrow . tr
+
+
+infixl 2 ===
+(===) :: (KnownNat r1, KnownNat r2, KnownNat c) => L r1 c -> L r2 c -> L (r1+r2) c
+a === b = mkL (extract a LA.=== extract b)
+
+
+infixl 3 |||
+(|||) :: (KnownNat r, KnownNat c1, KnownNat c2, KnownNat (c1+c2)) => L r c1 -> L r c2 -> L r (c1+c2)
+a ||| b = tr (tr a === tr b)
+
+
+type Sq n  = L n n
+--type CSq n = CL n n
+
+
+isKonst :: forall m n . (KnownNat m, KnownNat n) => L m n -> Maybe (ℝ,(Int,Int))
+isKonst s@(unwrap -> x)
+    | singleM x = Just (x `atIndex` (0,0), size s)
+    | otherwise = Nothing
+
+isKonstV :: forall n . KnownNat n => R n -> Maybe (ℝ,Int)
+isKonstV s@(unwrap -> x)
+    | singleV x = Just (x `atIndex` 0, size s)
+    | otherwise = Nothing
+
+-- isKonstC :: forall m n . (KnownNat m, KnownNat n) => M m n -> Maybe (ℂ,(Int,Int))
+-- isKonstC s@(unwrap -> x)
+--     | singleM x = Just (x `atIndex` (0,0), (size s))
+--     | otherwise = Nothing
+
+
+infixr 8 <>
+(<>) :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => L m k -> L k n -> L m n
+(<>) = mul
+
+
+infixr 8 #>
+(#>) :: (KnownNat m, KnownNat n) => L m n -> R n -> R m
+(#>) = app
+
+
+infixr 8 <·>
+(<·>) :: KnownNat n => R n -> R n -> ℝ
+(<·>) = dot
+
+infixr 8 <.>
+(<.>) :: KnownNat n => R n -> R n -> ℝ
+(<.>) = dot
+
+--------------------------------------------------------------------------------
+
+class Diag m d | m -> d
+  where
+    takeDiag :: m -> d
+
+
+instance KnownNat n => Diag (L n n) (R n)
+  where
+    takeDiag x = mkR (LA.takeDiag (extract x))
+
+
+instance KnownNat n => Diag (M n n) (C n)
+  where
+    takeDiag x = mkC (LA.takeDiag (extract x))
+
+--------------------------------------------------------------------------------
+
+
+-- toComplex :: KnownNat n => (R n, R n) -> C n
+-- toComplex (r,i) = mkC $ LA.toComplex (ud1 r, ud1 i)
+
+-- fromComplex :: KnownNat n => C n -> (R n, R n)
+-- fromComplex (C (Dim v)) = let (r,i) = LA.fromComplex v in (mkR r, mkR i)
+
+-- complex :: KnownNat n => R n -> C n
+-- complex r = mkC $ LA.toComplex (ud1 r, LA.konst 0 (size r))
+
+-- real :: KnownNat n => C n -> R n
+-- real = fst . fromComplex
+
+-- imag :: KnownNat n => C n -> R n
+-- imag = snd . fromComplex
+
+-- sqMagnitude :: KnownNat n => C n -> R n
+-- sqMagnitude c = let (r,i) = fromComplex c in r**2 + i**2
+
+-- magnitude :: KnownNat n => C n -> R n
+-- magnitude = sqrt . sqMagnitude
+
+--------------------------------------------------------------------------------
+
+linSolve :: (KnownNat m, KnownNat n) => L m m -> L m n -> Maybe (L m n)
+linSolve (extract -> a) (extract -> b) = fmap mkL (LA.linearSolve a b)
+
+(<\>) :: (KnownNat m, KnownNat n, KnownNat r) => L m n -> L m r -> L n r
+(extract -> a) <\> (extract -> b) = mkL (a LA.<\> b)
+
+--------------------------------------------------------------------------------
+
+split :: forall p n . (KnownNat p, KnownNat n, p<=n) => R n -> (R p, R (n-p))
+split (extract -> v) = ( mkR (subVector 0 p' v) ,
+                         mkR (subVector p' (LA.size v - p') v) )
+  where
+    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
+
+
+headTail :: (KnownNat n, 1<=n) => R n -> (ℝ, R (n-1))
+headTail = ((! 0) . extract *** id) . split
+
+
+splitRows :: forall p m n . (KnownNat p, KnownNat m, KnownNat n, p<=m) => L m n -> (L p n, L (m-p) n)
+splitRows (extract -> x) = ( mkL (takeRows p' x) ,
+                             mkL (dropRows p' x) )
+  where
+    p' = fromIntegral . natVal $ (undefined :: Proxy p) :: Int
+
+splitCols :: forall p m n. (KnownNat p, KnownNat m, KnownNat n, KnownNat (n-p), p<=n) => L m n -> (L m p, L m (n-p))
+splitCols = (tr *** tr) . splitRows . tr
+
+
+toRows :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R n]
+toRows (LA.toRows . extract -> vs) = map mkR vs
+
+withRows
+    :: forall n z . KnownNat n
+    => [R n]
+    -> (forall m . KnownNat m => L m n -> z)
+    -> z
+withRows (LA.fromRows . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.rows m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) -> f (mkL m :: L m n)
+
+toColumns :: forall m n . (KnownNat m, KnownNat n) => L m n -> [R m]
+toColumns (LA.toColumns . extract -> vs) = map mkR vs
+
+withColumns
+    :: forall m z . KnownNat m
+    => [R m]
+    -> (forall n . KnownNat n => L m n -> z)
+    -> z
+withColumns (LA.fromColumns . map extract -> m) f =
+    case someNatVal $ fromIntegral $ LA.cols m of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy n)) -> f (mkL m :: L m n)
+
+
+
+--------------------------------------------------------------------------------
+
+build
+  :: forall m n . (KnownNat n, KnownNat m)
+    => (ℝ -> ℝ -> ℝ)
+    -> L m n
+build f = r
+  where
+    r = mkL $ LA.build (size r) f
+
+--------------------------------------------------------------------------------
+
+withVector
+    :: forall z
+     . Vector ℝ
+    -> (forall n . (KnownNat n) => R n -> z)
+    -> z
+withVector v f =
+    case someNatVal $ fromIntegral $ LA.size v of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) -> f (mkR v :: R m)
+
+-- | Useful for constraining two dependently typed vectors to match each
+-- other in length when they are unknown at compile-time.
+exactLength
+    :: forall n m . (KnownNat n, KnownNat m)
+    => R m
+    -> Maybe (R n)
+exactLength v = do
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy m)
+    return $ mkR (unwrap v)
+
+withMatrix
+    :: forall z
+     . Matrix ℝ
+    -> (forall m n . (KnownNat m, KnownNat n) => L m n -> z)
+    -> z
+withMatrix a f =
+    case someNatVal $ fromIntegral $ rows a of
+       Nothing -> error "static/dynamic mismatch"
+       Just (SomeNat (_ :: Proxy m)) ->
+           case someNatVal $ fromIntegral $ cols a of
+               Nothing -> error "static/dynamic mismatch"
+               Just (SomeNat (_ :: Proxy n)) ->
+                  f (mkL a :: L m n)
+
+-- | Useful for constraining two dependently typed matrices to match each
+-- other in dimensions when they are unknown at compile-time.
+exactDims
+    :: forall n m j k . (KnownNat n, KnownNat m, KnownNat j, KnownNat k)
+    => L m n
+    -> Maybe (L j k)
+exactDims m = do
+    Refl <- sameNat (Proxy :: Proxy m) (Proxy :: Proxy j)
+    Refl <- sameNat (Proxy :: Proxy n) (Proxy :: Proxy k)
+    return $ mkL (unwrap m)
+
+
+--------------------------------------------------------------------------------
+
+mul :: forall m k n. (KnownNat m, KnownNat k, KnownNat n) => L m k -> L k n -> L m n
+mul (isKonst -> Just (a,(_,k))) (isKonst -> Just (b,_)) = konst (a * b * fromIntegral k)
+mul (isDiag -> Just (0,a,_)) (isDiag -> Just (0,b,_)) = diagR 0 (mkR v :: R k)
+  where
+    v = a' * b'
+    n = min (LA.size a) (LA.size b)
+    a' = subVector 0 n a
+    b' = subVector 0 n b
+-- mul (isDiag -> Just (0,a,_)) (extract -> b) = mkL (asColumn a * takeRows (LA.size a) b)
+-- mul (extract -> a) (isDiag -> Just (0,b,_)) = mkL (takeColumns (LA.size b) a * asRow b)
+mul a b = mkL (extract a LA.<> extract b)
+
+
+app :: (KnownNat m, KnownNat n) => L m n -> R n -> R m
+app (isDiag -> Just (0, w, _)) v = mkR (w * subVector 0 (LA.size w) (extract v))
+app m v = mkR (extract m LA.#> extract v)
+
+
+dot :: KnownNat n => R n -> R n -> ℝ
+dot (extract -> u) (extract -> v) = LA.dot u v
+
+
+cross :: R 3 -> R 3 -> R 3
+cross (extract -> x) (extract -> y) = vec3 z1 z2 z3
+  where
+    z1 = x!1*y!2-x!2*y!1
+    z2 = x!2*y!0-x!0*y!2
+    z3 = x!0*y!1-x!1*y!0
+
+outer :: (KnownNat m, KnownNat n) => R n -> R m -> L n m
+outer (extract -> x) (extract -> y) = mkL (LA.outer x y)
+
+mapR :: KnownNat n => (ℝ -> ℝ) -> R n -> R n
+mapR f (unwrap -> v) = mkR (LA.cmap f v)
+
+zipWith :: KnownNat n => (ℝ -> ℝ -> ℝ) -> R n -> R n -> R n
+zipWith f (extract -> x) (extract -> y) = mkR (LA.zipVectorWith f x y)
+
+mapL :: (KnownNat n, KnownNat m) => (ℝ -> ℝ) -> L n m -> L n m
+mapL f = overMatL' (LA.cmap f)
+
+det :: KnownNat n => Sq n -> ℝ
+det = LA.det . unwrap
+
+invlndet :: KnownNat n => Sq n -> (L n n, (ℝ, ℝ))
+invlndet = BF.first mkL . LA.invlndet . unwrap
+
+expm :: KnownNat n => Sq n -> Sq n
+expm = overMatL' LA.expm
+
+sqrtm :: KnownNat n => Sq n -> Sq n
+sqrtm = overMatL' LA.sqrtm
+
+inv :: KnownNat n => Sq n -> Sq n
+inv = overMatL' LA.inv
+
+flatten :: (KnownNat m, KnownNat n, KnownNat (m * n)) => L m n -> R (m * n)
+flatten (extract -> mat') = vector (LA.toList (LA.flatten mat'))
+
+reshape :: forall m n k. (KnownNat m, KnownNat n, KnownNat k, n ~ (k * m)) => R n -> L k m
+reshape (extract -> v) = mkL $ LA.reshape nrow v
+  where
+    nrow = (fromIntegral . natVal) (undefined :: Proxy k)
+
+
+diagR :: forall m n k . (KnownNat m, KnownNat n, KnownNat k) => ℝ -> R k -> L m n
+diagR x v
+    | m' == 1 = mkL (LA.diagRect x ev m' n')
+    | m'*n' > 0 = r
+    | otherwise = matrix []
+  where
+    r = mkL (asRow (vjoin [scalar x, ev, zeros]))
+    ev = extract v
+    zeros = LA.konst x (max 0 ((min m' n') - LA.size ev))
+    (m',n') = size r
+
+
+
+mean :: (KnownNat n, 1<=n) => R n -> ℝ
+mean v = v <·> (1/dim)
+
+
+--------------------------------------------------------------------------------
+-- Element access using the Finite type
+
+vAt :: KnownNat n => R n -> Finite n -> ℝ
+vAt v i = extract v LA.! fromIntegral (getFinite i)
+
+mAt :: (KnownNat m, KnownNat n) => L m n -> Finite m -> Finite n -> ℝ
+mAt m i' j' = extract m `LA.atIndex` (i, j)
+  where i = fromIntegral (getFinite i')
+        j = fromIntegral (getFinite j')


### PR DESCRIPTION
As the continuation-passing style of the existential type is hard to pass around, its wrapper is introduced.

For example, we can't make a list of the CPS of the existential type as below
![2022-03-11_15-41](https://user-images.githubusercontent.com/88674591/157816072-028516c1-1c41-45de-9257-c5a787521c3c.png)

However, the existential type is wrapped with a constructor, this is possible to make a list.
```haskell
data SomeTest = forall z. SomeTest (Test z)

x1' :: SomeTest
x1' = SomeTest (Test 10.0)

x2' :: SomeTest
x2' = SomeTest (Test 10.0)

xs' :: [SomeTest]
xs' = [x1', x2']

```