### PR TITLE
Expose internal modules; fixes #359, #235

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -64,8 +64,7 @@ library
                         Numeric.LinearAlgebra.Data
                         Numeric.LinearAlgebra.HMatrix
                         Numeric.LinearAlgebra.Static
-
-    other-modules:      Internal.Vector
+                        Internal.Vector
                         Internal.Devel
                         Internal.Vectorized
                         Internal.Matrix

--- a/packages/base/src/Numeric/Vector.hs
+++ b/packages/base/src/Numeric/Vector.hs
@@ -20,7 +20,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Numeric.Vector () where
+module Numeric.Vector (adaptScalar) where
 
 import Internal.Vectorized
 import Internal.Vector


### PR DESCRIPTION
Here are instances of hmatrix classes for a newtype of Double made possible by this PR:  https://github.com/Mikolaj/horde-ad/blob/01f5b467d1b0ccf9e8e4244e0837829f857a6807/src/HordeAd/Internal/HmatrixOrphanInstances.hs

They are tested and work fine. Making derivation of the instances easier and less susceptible to breakage when hmatrix changes would be very welcome, but just exposing internal modules is enough for me and I won't need to make a fork (which would be a horror to maintain, I'm sure).

