### PR TITLE
change unwrap to extract in overMatL' and overMatM'

### DIFF
--- a/packages/base/src/Internal/Static.hs
+++ b/packages/base/src/Internal/Static.hs
@@ -571,12 +571,12 @@ instance KnownNat n => Disp (C n)
 
 overMatL' :: (KnownNat m, KnownNat n)
           => (LA.Matrix ℝ -> LA.Matrix ℝ) -> L m n -> L m n
-overMatL' f = mkL . f . unwrap
+overMatL' f = mkL . f . extract
 {-# INLINE overMatL' #-}
 
 overMatM' :: (KnownNat m, KnownNat n)
           => (LA.Matrix ℂ -> LA.Matrix ℂ) -> M m n -> M m n
-overMatM' f = mkM . f . unwrap
+overMatM' f = mkM . f . extract
 {-# INLINE overMatM' #-}
 
 


### PR DESCRIPTION
@lsg6140 and I've found this bug in the `overMatL'` and `overMatM'` functions.

A reduced example case we found is that

```haskell
{-# LANGUAGE DataKinds #-}

module Main where

import qualified Numeric.LinearAlgebra.Static as H
rmat = H.matrix [1,2,3,4] :: H.L 2 2
cmat = H.matrix [1,2,3,4] :: H.M 2 2

invDiagR = H.inv $ H.diag (H.vector [1,2] :: H.R 2)
invDiagC = H.inv $ H.diag (H.vector [1,2] :: H.C 2)
```

After loading this module in ghci, executing `invDiagR` and `invDiagC` produces these errors:
```ghci
*Main> invDiagR
*** Exception: inv of nonsquare (1x3) matrix
CallStack (from HasCallStack):
  error, called at src/Internal/Algorithms.hs:706:21 in hmatrix-0.20.2-inplace:Internal.Algorithms
*Main> invDiagC
*** Exception: inv of nonsquare (1x3) matrix
CallStack (from HasCallStack):
  error, called at src/Internal/Algorithms.hs:706:21 in hmatrix-0.20.2-inplace:Internal.Algorithms
```

By replacing `unwrap` with `extract` in the definition of `overMatL` and `overMatM` functions, we've
checked that we have the expected results:
```ghci
*Main> invDiagR 
(matrix
 [ 1.0, 0.0
 , 0.0, 0.5 ] :: L 2 2)
*Main> invDiagC
(matrix
 [ 1.0 :+ 0.0, 0.0 :+ 0.0
 , 0.0 :+ 0.0, 0.5 :+ 0.0 ] :: M 2 2)
```