### PR TITLE
Require split >= 0.2

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -50,7 +50,7 @@ library
                         array,
                         deepseq,
                         random,
-                        split,
+                        split >= 0.2,
                         bytestring,
                         primitive,
                         storable-complex,


### PR DESCRIPTION
`chunksOf` is not available earlier than `split-0.2`.

As a Hackage trustee I made matching revisions.