### PR TITLE
Functions to create constant matrices

### DIFF
--- a/packages/base/src/Numeric/LinearAlgebra/Static.hs
+++ b/packages/base/src/Numeric/LinearAlgebra/Static.hs
@@ -466,6 +466,25 @@ build f = r
   where
     r = mkL $ LA.build (size r) f
 
+-- | Create a matrix where every element is the same.
+constMatrix
+  :: forall m n . (KnownNat n, KnownNat m)
+    => ℝ
+    -> L m n
+constMatrix x = build (\_ _ -> x)
+
+-- | Create a matrix where every element is zero.
+zeros
+  :: forall m n . (KnownNat n, KnownNat m)
+    => L m n
+zeros = constMatrix 0
+
+-- | Create a matrix where every element is one.
+ones
+  :: forall m n . (KnownNat n, KnownNat m)
+    => L m n
+ones = constMatrix 1
+
 --------------------------------------------------------------------------------
 
 withVector


### PR DESCRIPTION
Hi,

I made [a blog post](https://nicaudinet.github.io/2024/02/11/hmatrix-zeros-to-hero/) the other day about adding a `zeros` function to Hmatrix. Thought I would make a pull request as well while I'm at it :)

I introduce three functions for easily creating matrices: `zeros` and `ones` to create matrices filled with zeros and ones respectively (following Numpy's naming convention). I also added a more general `constMatrix` function to create matrices with any value.

-Nicolas