### PR TITLE
Accelerate framework is not necessary when using openblas

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -116,6 +116,7 @@ library
             extra-libraries:    openblas
         else
             extra-libraries:    blas lapack
+            frameworks: Accelerate
 
         if !flag(disable-default-paths)
             extra-lib-dirs: /opt/local/lib/
@@ -124,7 +125,6 @@ library
             include-dirs: /usr/local/include/
         if arch(i386)
             cc-options: -arch i386
-        frameworks: Accelerate
 
     if os(freebsd)
         if flag(openblas)


### PR DESCRIPTION
`Accelerate` is a framework that provides BLAS and LAPACK. And I think that `Accelerate` is unnecessary if you use BLAS/LAPACK provided by other libraries such as `openblas`.

I tested the PR with macOS 13.6.6 on Apple M1, GHC-9.6.5 (aarch64-osx), openblas-0.3.27 from HomeBrew, and the following `stack.yaml`:

```yaml
flags:
  hmatrix:
    openblas: true
  hmatrix-special:
    safe-cheap: false
  hmatrix-tests:
    gsl: true
  hmatrix-gsl:
    onlygsl: false
packages:
- packages/tests/
- packages/special/
- packages/gsl/
- packages/glpk/
- packages/base/
- examples/
resolver: lts-22.26
nix:
  path: [nixpkgs=./nixpkgs.nix]
  shell-file: shell.nix
extra-include-dirs:
- /opt/homebrew/Cellar/openblas/0.3.27/include
extra-lib-dirs:
- /opt/homebrew/Cellar/openblas/0.3.27/lib
```

`stack test` works fine except for the following error:

```
hmatrix-tests  > ------ ldlSolve
hmatrix-tests  > +++ OK, passed 100 tests.
hmatrix-tests  > *** Failed! (after 5 tests):
hmatrix-tests  > Exception:
hmatrix-tests  >   ldlC: code 1
hmatrix-tests  >   CallStack (from HasCallStack):
hmatrix-tests  >     error, called at src/Internal/Devel.hs:52:21 in hmatrix-0.20.2-DaXP0Zz4Wa0HRiizEPfZT2:Internal.Devel
hmatrix-tests  > SqWC (1><1)
hmatrix-tests  >  [ 0.0 :+ 17.11902914746234 ]
hmatrix-tests  > Test suite hmatrix-base-testsuite failed
```

This error happened even when I used `Accelerate`, so it would be a different issue. If I commented out the test case, everything worked fine.